### PR TITLE
Add support for multiple types collections

### DIFF
--- a/lib/dolly/collection.rb
+++ b/lib/dolly/collection.rb
@@ -48,7 +48,8 @@ module Dolly
         properties = r['doc']
         id = properties.delete '_id'
         rev = properties.delete '_rev' if properties['_rev']
-        document = docs_class.new properties
+        doc_class = doc_class id
+        document = doc_class.new properties
         document.doc = properties.merge({'_id' => id, '_rev' => rev})
         @set << document
       end
@@ -68,6 +69,11 @@ module Dolly
     private
     def docs_class
       @docs_class
+    end
+
+    def doc_class id
+      doc_class = id[/^[a-z_]+/].camelize.constantize
+      docs_class == doc_class ? docs_class : doc_class
     end
 
     def json

--- a/lib/dolly/collection.rb
+++ b/lib/dolly/collection.rb
@@ -72,6 +72,10 @@ module Dolly
     end
 
     def doc_class id
+      # TODO: We need to improve and document the way we return
+      # multiple types when querying from a class, as it might
+      # be confusing. We *could* also get dolly to parse the result
+      # before sending it back to the client.
       doc_class = id[/^[a-z_]+/].camelize.constantize
       docs_class == doc_class ? docs_class : doc_class
     end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -11,6 +11,8 @@ class FooBar < Dolly::Document
   timestamps!
 end
 
+class Baz < Dolly::Document; end
+
 class DocumentTest < ActiveSupport::TestCase
   DB_BASE_PATH = "http://localhost:5984/test".freeze
 
@@ -23,6 +25,7 @@ class DocumentTest < ActiveSupport::TestCase
     empty_resp  =  build_view_response []
     not_found_resp = generic_response [{ key: "foo_bar/2", error: "not_found" }]
     @multi_resp = build_view_response all_docs
+    @multi_type_resp = build_view_collation_response all_docs
 
     build_request [["foo_bar","1"]], view_resp
     build_request [["foo_bar","2"]], empty_resp
@@ -223,6 +226,14 @@ class DocumentTest < ActiveSupport::TestCase
     f.each{ |d| assert d.kind_of?(FooBar) }
   end
 
+  test 'query custom view collation' do
+    FakeWeb.register_uri :get, "http://localhost:5984/test/_design/test/_view/custom_view?startkey=%5B1%5D&endkey=%5B1%2C%7B%7D%5D&include_docs=true", body: @multi_type_resp.to_json
+    f = FooBar.find_with "test", "custom_view", { startkey: [1], endkey: [1, {}]}
+    assert_equal 2, f.count
+    assert f.first.kind_of?(FooBar)
+    assert f.last.kind_of?(Baz)
+  end
+
   test 'new document have id' do
     foo = FooBar.new
     assert_equal 0, (foo.id =~ /^foo_bar\/[abcdef0-9]+/i)
@@ -283,6 +294,20 @@ class DocumentTest < ActiveSupport::TestCase
     end
     generic_response rows, properties.count
   end
+
+  def build_view_collation_response properties
+    rows = properties.map.with_index do |v, i|
+      id = i.zero? ? "foo_bar/#{i}" : "baz/#{i}"
+      {
+        id: id,
+        key: "foo_bar",
+        value: 1,
+        doc: {_id: id, _rev: SecureRandom.hex}.merge!(v)
+      }
+    end
+    generic_response rows, properties.count
+  end
+
 
   def build_request keys, body, view_name = 'foo_bar'
     query = "keys=#{CGI::escape keys.to_s.gsub(' ','')}&" unless keys.blank?


### PR DESCRIPTION
Fixes #44 

This makes `Collection` derive the type of the doc based on it's `_id`. E.g.: a collection set containing objects with ids `post/abc123` and `comment/def456` will return a collection with both a `Post` and a `Comment` objects.

Implementation of this feature shouldn't break current API, thus allowing for a smooth transition from homogenic to diverse collections.