### PR TITLE
Capture 400 errors that are not 404 properly

### DIFF
--- a/lib/dolly/request.rb
+++ b/lib/dolly/request.rb
@@ -61,8 +61,8 @@ module Dolly
       response = self.class.send method, resource, data.merge(headers: headers)
       if response.code == 404
         raise Dolly::ResourceNotFound
-      elsif (500..600).include? response.code
-        raise Dolly::ServerError
+      elsif (400..600).include? response.code
+        raise Dolly::ServerError.new( response )
       else
         response
       end

--- a/lib/exceptions/dolly.rb
+++ b/lib/exceptions/dolly.rb
@@ -5,8 +5,12 @@ module Dolly
     end
   end
   class ServerError < RuntimeError
+    def initialize msg
+      @msg = msg
+    end
+
     def to_s
-      'There has been an error on the couchdb server. Please review your couch logs.'
+      "There has been an error on the couchdb server: #{@msg.inspect}"
     end
   end
   class MissingDesignError < RuntimeError


### PR DESCRIPTION
- Provide the reason in the exception output that is provided to help
  diagnose issues.
- Properly stops work on authentication errors