### PR TITLE
Run validations on `save`

### DIFF
--- a/lib/dolly/document.rb
+++ b/lib/dolly/document.rb
@@ -51,7 +51,8 @@ module Dolly
       doc['_rev'] = value
     end
 
-    def save
+    def save options = {}
+      return false unless options[:validate] == false || valid?
       self.doc['_id'] = self.id if self.id.present?
       self.doc['_id'] = self.class.next_id if self.doc['_id'].blank?
       set_created_at if timestamps

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -410,6 +410,18 @@ class DocumentTest < ActiveSupport::TestCase
     end
   end
 
+  test 'save returns false for invalid document on save' do
+    foo = DocumentWithValidMethod.new
+    assert_not foo.save
+  end
+
+  test 'save succeeds for invalid document if skipping validations' do
+    resp = {ok: true, id: "document_with_valid_method/1", rev: "FF0000"}
+    FakeWeb.register_uri :put, /http:\/\/localhost:5984\/test\/document_with_valid_method%2F.+/, body: resp.to_json
+    foo = DocumentWithValidMethod.new
+    assert foo.save(validate: false)
+  end
+
   private
   def generic_response rows, count = 1
     {total_rows: count, offset:0, rows: rows}


### PR DESCRIPTION
In an effort to replicate the way active model validations work, this will run validations on regular `save`, returning `false` on validation error. There's also an option to skip validations altogether by using `save(validate: false)`.

@seancookr @javierg Review needed.