### PR TITLE
add support for inline attachments completes #97

### DIFF
--- a/lib/dolly/document.rb
+++ b/lib/dolly/document.rb
@@ -1,6 +1,7 @@
 require "dolly/query"
 require "dolly/property"
 require 'dolly/timestamps'
+require 'base64'
 
 module Dolly
   class Document
@@ -98,8 +99,15 @@ module Dolly
       CGI::escape id
     end
 
-    def attach_file! file_name, mime_type, body
-      database.attach id_as_resource, CGI.escape(file_name), body, { 'Content-Type' => mime_type }
+    def attach_file! file_name, mime_type, body, inline=false
+      if inline
+        attachment_data = { file_name.to_s => { 'content_type' => mime_type,
+                                                'data'         => Base64.encode64(body)} }
+        doc['_attachments'].merge attachment_data
+        save
+      else
+        database.attach id_as_resource, CGI.escape(file_name), body, { 'Content-Type' => mime_type }
+      end
     end
 
     def self.create options = {}

--- a/lib/dolly/document.rb
+++ b/lib/dolly/document.rb
@@ -99,11 +99,12 @@ module Dolly
       CGI::escape id
     end
 
-    def attach_file! file_name, mime_type, body, inline=false
-      if inline
+    def attach_file! file_name, mime_type, body, opts={}
+      if opts[:inline]
         attachment_data = { file_name.to_s => { 'content_type' => mime_type,
                                                 'data'         => Base64.encode64(body)} }
-        doc['_attachments'].merge attachment_data
+        doc['_attachments'] ||= {}
+        doc['_attachments'].merge! attachment_data
         save
       else
         database.attach id_as_resource, CGI.escape(file_name), body, { 'Content-Type' => mime_type }

--- a/lib/dolly/document.rb
+++ b/lib/dolly/document.rb
@@ -1,7 +1,6 @@
 require "dolly/query"
 require "dolly/property"
 require 'dolly/timestamps'
-require 'base64'
 
 module Dolly
   class Document


### PR DESCRIPTION
This PR adds the option for inline attachments as discussed here 

http://elegantcode.com/2009/07/10/adding-attachments-to-documents-in-couchdb/

