### PR TITLE
Inheretance persist properties into parent object

### DIFF
--- a/lib/dolly/document.rb
+++ b/lib/dolly/document.rb
@@ -79,6 +79,10 @@ module Dolly
       raise Dolly::ResourceNotFound if col.empty?
       col.each{ |r| @doc = r['doc'] }
       _properties.each do |p|
+        #TODO: Refactor properties so it is not required
+        #to be a class property. But something that doesn't
+        #persist all the inheretence chain
+        next unless self.respond_to? :"#{p.name}="
         self.send "#{p.name}=", doc[p.name]
       end
       @rows = col

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -49,6 +49,10 @@ class DocWithSameDefaults < Dolly::Document
   property :foo, :bar, class_name: Array, default: []
 end
 
+class Bar < FooBar
+  property :a, :b
+end
+
 class DocumentTest < ActiveSupport::TestCase
   DB_BASE_PATH = "http://localhost:5984/test".freeze
 
@@ -465,6 +469,10 @@ class DocumentTest < ActiveSupport::TestCase
     assert doc.attach_file! 'test.txt', 'text/plain', data, inline: true
     assert doc.doc['_attachments']['test.txt'].present?
     assert_equal Base64.encode64(data), doc.doc['_attachments']['test.txt']['data']
+  end
+
+  test "new object from inhereted document" do
+    assert Bar.new(a: 1)
   end
 
   private

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -472,7 +472,8 @@ class DocumentTest < ActiveSupport::TestCase
   end
 
   test "new object from inhereted document" do
-    assert Bar.new(a: 1)
+    assert bar = Bar.new(a: 1)
+    assert_equal 1, bar.a
   end
 
   private


### PR DESCRIPTION
This bugs prevents from using inheretance as the children classes inject properties into the original Object causing missing method issues