### PR TITLE
rake task imports .lib files

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -25,6 +25,9 @@ namespace :db do
         vd['filters'][name] = source
       elsif key == 'lists'
         vd['lists'][name] = source
+      elsif key == 'lib'
+        v = vd['views']['lib'] ||= {}
+        v[name] = source
       else
         v = vd['views'][name] ||= {}
         v[key] = source


### PR DESCRIPTION
#### Completes: #104 

adding `.lib` files to the `db/design` folders will import modules into couch.

here is an example of how this works. 

`module_name.lib.coffee`
```
exports.str = 'hello world'
exports.arr = [1,2,3,4,5]
....
```

couch views
```
(d) ->
  if d._id.indexOf("example/") is 0
    emit d._id, { module_array: require('views/lib/module_name').arr }
```