### PR TITLE
Add bulk properties update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    dolly (1.0.0)
+    dolly (1.0.1)
       httparty
       railties
 

--- a/lib/dolly/collection.rb
+++ b/lib/dolly/collection.rb
@@ -22,7 +22,18 @@ module Dolly
 
     def update_properties! properties ={}
       properties.each do |key, value|
-        json.gsub! %r{\"#{key}\":\"[^\"]+\"}, "\"#{key}\":\"#{value}\""
+
+        regex = %r{
+          \"#{key}\":  # find key definition in json string
+          (            # start value group
+            \"[^\"]*\" # find anything (even empty) between \" and \"
+            |          # logical OR
+            null       #literal null value
+          )            # end value group
+        }x
+
+        raise Dolly::MissingPropertyError unless json.match regex
+        json.gsub! regex, "\"#{key}\":\"#{value}\""
       end
 
       BulkDocument.new(Dolly::Document.database, to_a).save

--- a/lib/dolly/collection.rb
+++ b/lib/dolly/collection.rb
@@ -20,6 +20,15 @@ module Dolly
       to_a.last
     end
 
+    def update_properties! properties ={}
+      properties.each do |key, value|
+        json.gsub! %r{\"#{key}\":\"[^\"]+\"}, "\"#{key}\":\"#{value}\""
+      end
+
+      BulkDocument.new(Dolly::Document.database, to_a).save
+      self
+    end
+
     def map &block
       load if empty?
       @set.collect &block

--- a/lib/dolly/version.rb
+++ b/lib/dolly/version.rb
@@ -1,3 +1,3 @@
 module Dolly
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/lib/exceptions/dolly.rb
+++ b/lib/exceptions/dolly.rb
@@ -34,4 +34,5 @@ module Dolly
     end
   end
   class DocumentInvalidError < RuntimeError; end
+  class MissingPropertyError < RuntimeError; end
 end

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -42,4 +42,18 @@ class CollectionTest < ActiveSupport::TestCase
     assert_equal ['Foo 4 All', 'Foo 4 All'], @collection.map(&:foo)
   end
 
+  test 'update empty attributes' do
+    json = '{"total_rows":2,"offset":0,"rows":[{"id":"foo_bar/0","key":"foo_bar","value":1,"doc":{"_id":"foo_bar/0","_rev":"7f66379ac92eb6dfafa50c94bd795122","foo":null,"bar":"","type":"foo_bar"}},{"id":"foo_bar/1","key":"foo_bar","value":1,"doc":{"_id":"foo_bar/1","_rev":"4d33cea0e55142c9ecc6a81600095469","foo":"Foo A","bar":"Bar A","type":"foo_bar"}}]}'
+    collection = Dolly::Collection.new json, FooBar
+
+    collection.update_properties! foo: 'Foo 4 All', bar: 'stuff'
+    assert_equal ['Foo 4 All', 'Foo 4 All'], collection.map(&:foo)
+    assert_equal ['stuff', 'stuff'], collection.map(&:bar)
+  end
+
+  test 'ypdate attributes will raise exception if property is missing' do
+    assert_raise Dolly::MissingPropertyError do
+      @collection.update_properties! missing: 'Ha! Ha!'
+    end
+  end
 end

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -37,4 +37,9 @@ class CollectionTest < ActiveSupport::TestCase
     assert_equal ["Foo B", "Foo A"], @collection.map(&:foo)
   end
 
+  test 'update attributes will change expected attributes' do
+    @collection.update_properties! foo: 'Foo 4 All'
+    assert_equal ['Foo 4 All', 'Foo 4 All'], @collection.map(&:foo)
+  end
+
 end


### PR DESCRIPTION
This PR adds a method to update properties in bulk, it will set the same value to all the documents in the collection.

Open against 1.0 as I needed on some projects which still use this version of dolly