### PR TITLE
Do not allow a request to be instantiated with missing config data

### DIFF
--- a/lib/dolly/request.rb
+++ b/lib/dolly/request.rb
@@ -5,15 +5,17 @@ module Dolly
 
   class Request
     include HTTParty
-    DEFAULT_HOST = 'localhost'
-    DEFAULT_PORT = '5984'
+    REQUIRED_KEYS = %/host port name/
 
     attr_accessor :database_name, :host, :port, :bulk_document
 
     def initialize options = {}
-      @host = options["host"] || DEFAULT_HOST
-      @port = options["port"] || DEFAULT_PORT
+      REQUIRED_KEYS.each do |key|
+        raise Dolly::MissingRequestConfigSettings unless options[key]
+      end
 
+      @host          = options["host"]
+      @port          = options["port"]
       @database_name = options["name"]
       @username      = options["username"]
       @password      = options["password"]
@@ -50,7 +52,7 @@ module Dolly
     end
 
     def protocol
-      @protocol || 'http'
+      @protocol ||= 'http'
     end
 
     def uuids opts = {}

--- a/lib/dolly/request.rb
+++ b/lib/dolly/request.rb
@@ -5,13 +5,13 @@ module Dolly
 
   class Request
     include HTTParty
-    REQUIRED_KEYS = %w/host port name/
+    REQUIRED_KEYS = %w/host port name/.freeze
 
     attr_accessor :database_name, :host, :port, :bulk_document
 
     def initialize options = {}
       REQUIRED_KEYS.each do |key|
-        raise Dolly::MissingRequestConfigSettings unless options[key]
+        raise Dolly::MissingRequestConfigSettings.new(key) unless options[key]
       end
 
       @host          = options["host"]

--- a/lib/dolly/request.rb
+++ b/lib/dolly/request.rb
@@ -5,7 +5,7 @@ module Dolly
 
   class Request
     include HTTParty
-    REQUIRED_KEYS = %/host port name/
+    REQUIRED_KEYS = %w/host port name/
 
     attr_accessor :database_name, :host, :port, :bulk_document
 

--- a/lib/exceptions/dolly.rb
+++ b/lib/exceptions/dolly.rb
@@ -35,4 +35,13 @@ module Dolly
   end
   class DocumentInvalidError < RuntimeError; end
   class MissingPropertyError < RuntimeError; end
+  class MissingRequestConfigSettings < RuntimeError
+    def initialize key
+      @key = key
+    end
+
+    def to_s
+      "Missing #{@key} for Dolly::Request"
+    end
+  end
 end

--- a/lib/exceptions/dolly.rb
+++ b/lib/exceptions/dolly.rb
@@ -41,7 +41,7 @@ module Dolly
     end
 
     def to_s
-      "Missing reuired #{@key} setting for Dolly::Request"
+      "Missing required #{@key} setting for Dolly::Request"
     end
   end
 end

--- a/lib/exceptions/dolly.rb
+++ b/lib/exceptions/dolly.rb
@@ -41,7 +41,7 @@ module Dolly
     end
 
     def to_s
-      "Missing #{@key} for Dolly::Request"
+      "Missing reuired #{@key} setting for Dolly::Request"
     end
   end
 end

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class RequestTest < ActiveSupport::TestCase
+  def setup
+    @default_settings = {'host' => 'www.test.com', 'port' => '5894', 'name' => 'database_name'}
+  end
+
+  test 'raises error when intialized without a host' do
+    assert_raise Dolly::MissingRequestConfigSettings do
+      Dolly::Request.new @default_settings.dup.delete('host')
+    end
+  end
+
+  test 'raises error when intialized without a name' do
+    assert_raise Dolly::MissingRequestConfigSettings do
+      Dolly::Request.new @default_settings.dup.delete('name')
+    end
+  end
+
+  test 'raises error when intialized without a port' do
+    assert_raise Dolly::MissingRequestConfigSettings do
+      Dolly::Request.new @default_settings.dup.delete('port')
+    end
+  end
+end


### PR DESCRIPTION
Removing the default options for the port and and adding exceptions for missing config options will ensure that Dolly will raises an error when there is no data set, and will no longer fall back silently using the default host and port (Which causes a problem when the database is not on the same box as the host)