### PR TITLE
Remove parsing from db responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 Dolly is a Object Oriented CouchDB interface to interact with the JSON documents through CouchDB's RESTful API.
 
+## Versions
+
+### Dolly 1.x
+
+It is only compatible with CouchDB 1.x
+
+### Dolly 2.x
+
+Dolly 2.x is compatible only with CouchDB 2.x and up
+
+#### Braking changes
+
+  * Due to fix on HTTParty, now `parsed_response` returns a `Hash` instead of a `JSON` string.
+    So no need to call `JSON.parse` on db responses.
+  * CochDB 2.0 will not accept post requests to views without a rquest body.
+  * No need to call `to_json` on body values for requests
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/dolly/collection.rb
+++ b/lib/dolly/collection.rb
@@ -17,23 +17,13 @@ module Dolly
 
     def update_properties! properties ={}
       properties.each do |key, value|
-
-        regex = %r{
-          \"#{key}\":  # find key definition in json string
-          (            # start value group
-            \"[^\"]*\" # find anything (even empty) between \" and \"
-            |          # logical OR
-            null       #literal null value
-          )            # end value group
-        }x
-
-        raise Dolly::MissingPropertyError unless json.match regex
-        json.gsub! regex, "\"#{key}\":\"#{value}\""
+        each do |doc|
+          raise Dolly::MissingPropertyError unless doc.respond_to? key.to_sym
+          doc.send(:"#{key}=", value)
+        end
       end
 
       BulkDocument.new(Dolly::Document.database, to_a).save
-      clear
-      load
       self
     end
 

--- a/lib/dolly/collection.rb
+++ b/lib/dolly/collection.rb
@@ -1,11 +1,11 @@
 module Dolly
   class Collection < DelegateClass(Set)
-    attr_accessor :rows
+    attr_accessor :rows, :collection
     attr_writer :json, :docs_class
 
-    def initialize str, docs_class
+    def initialize collection, docs_class
       @docs_class = docs_class
-      @json = str
+      @collection = collection
       initial = []
       super(initial)
       load
@@ -57,8 +57,7 @@ module Dolly
     end
 
     def load
-      parsed = JSON::parse json
-      self.rows = parsed['rows']
+      self.rows = collection['rows']
     end
 
     def to_json options = {}
@@ -81,7 +80,7 @@ module Dolly
     end
 
     def json
-      @json
+      @json ||= @collection.to_json
     end
 
   end

--- a/lib/dolly/document.rb
+++ b/lib/dolly/document.rb
@@ -64,7 +64,7 @@ module Dolly
       set_created_at if timestamps[self.class.name]
       set_updated_at if timestamps[self.class.name]
       response = database.put(id_as_resource, self.doc.to_json)
-      obj = JSON::parse response.parsed_response
+      obj = response.parsed_response
       doc['_rev'] = obj['rev'] if obj['rev']
       obj['ok']
     end
@@ -78,7 +78,7 @@ module Dolly
       if hard
         q = id_as_resource + "?rev=#{rev}"
         response = database.delete(q)
-        JSON::parse response.parsed_response
+        response.parsed_response
       else
         self.doc['_deleted'] = true
         self.save

--- a/lib/dolly/property.rb
+++ b/lib/dolly/property.rb
@@ -4,7 +4,7 @@ module Dolly
     attr_accessor :name
     attr_reader :class_name, :default
 
-    CANT_CLONE = [NilClass, TrueClass, FalseClass, Fixnum].freeze
+    CANT_CLONE = [NilClass, TrueClass, FalseClass, Integer].freeze
 
     def initialize opts = {}
       @class_name = opts.delete(:class_name) if opts.present?

--- a/lib/dolly/property.rb
+++ b/lib/dolly/property.rb
@@ -4,7 +4,7 @@ module Dolly
     attr_accessor :name
     attr_reader :class_name, :default
 
-    CANT_CLONE = [NilClass, TrueClass, FalseClass, Integer].freeze
+    CANT_CLONE = [NilClass, TrueClass, FalseClass, Fixnum].freeze
 
     def initialize opts = {}
       @class_name = opts.delete(:class_name) if opts.present?

--- a/lib/dolly/query.rb
+++ b/lib/dolly/query.rb
@@ -18,7 +18,7 @@ module Dolly
         if keys.count > 1
           build_collection( query_hash )
         else
-          self.new.from_json( database.all_docs(query_hash).parsed_response )
+          self.new( database.all_docs(query_hash).parsed_response )
         end
       rescue NoMethodError => err
         if err.message == "undefined method `[]' for nil:NilClass"
@@ -72,7 +72,7 @@ module Dolly
       end
 
       def raw_view doc, view, opts = {}
-        JSON.parse database.get "_design/#{doc}/_view/#{view}", opts
+        database.get "_design/#{doc}/_view/#{view}", opts
       end
 
     end

--- a/lib/dolly/query.rb
+++ b/lib/dolly/query.rb
@@ -18,7 +18,7 @@ module Dolly
         if keys.count > 1
           build_collection( query_hash )
         else
-          self.new( database.all_docs(query_hash).parsed_response )
+          self.new( database.all_docs(query_hash) )
         end
       rescue NoMethodError => err
         if err.message == "undefined method `[]' for nil:NilClass"
@@ -48,7 +48,7 @@ module Dolly
 
       def build_collection q
         res = database.all_docs(q)
-        Collection.new res.parsed_response, name_for_class
+        Collection.new res, name_for_class
       end
 
       def find_with doc, view_name, opts = {}

--- a/lib/dolly/request.rb
+++ b/lib/dolly/request.rb
@@ -60,14 +60,14 @@ module Dolly
     end
 
     def all_docs data = {}
-      data =  values_to_json data.merge( include_docs: true )
+      data = values_to_json data.merge( include_docs: true )
       request(:get, full_path('_all_docs'), { query: data }).parsed_response
     end
 
     def request method, resource, data = nil
       data ||= {}
       data.merge!(basic_auth: auth_info) if auth_info.present?
-      headers = { 'Content-Type' => 'application/json' }
+      headers = { 'Content-Type' => 'application/json', 'Accept' => "application/json" }
       headers.merge! data[:headers] if data[:headers]
       response = self.class.send method, resource, data.merge(headers: headers)
       log_request(resource, response.code) if Dolly.log_requests?

--- a/lib/dolly/request.rb
+++ b/lib/dolly/request.rb
@@ -61,7 +61,7 @@ module Dolly
 
     def all_docs data = {}
       data =  values_to_json data.merge( include_docs: true )
-      request :get, full_path('_all_docs'), {query: data}
+      request(:get, full_path('_all_docs'), { query: data }).parsed_response
     end
 
     def request method, resource, data = nil

--- a/lib/dolly/request.rb
+++ b/lib/dolly/request.rb
@@ -81,11 +81,12 @@ module Dolly
     end
 
     private
+
     def tools path, opts = nil
       data = {}
       q = "?#{CGI.unescape(opts.to_query)}" unless opts.blank?
       data.merge!(basic_auth: auth_info) if auth_info.present?
-      JSON::parse self.class.get("/#{path}#{q}", data)
+      self.class.get("/#{path}#{q}", data)
     end
 
     def auth_info

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -38,7 +38,7 @@ namespace :db do
       view_doc.merge!( '_id' => design_doc_name, 'language' => 'coffeescript')
 
       begin
-        hash_doc = JSON::parse Dolly::Document.database.get(view_doc["_id"]).parsed_response
+        hash_doc = Dolly::Document.database.get(view_doc["_id"]).parsed_response
 
         rev = hash_doc.delete('_rev')
 

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -10,7 +10,7 @@ class CollectionTest < ActiveSupport::TestCase
 
   def setup
     @json = '{"total_rows":2,"offset":0,"rows":[{"id":"foo_bar/0","key":"foo_bar","value":1,"doc":{"_id":"foo_bar/0","_rev":"7f66379ac92eb6dfafa50c94bd795122","foo":"Foo B","bar":"Bar B","type":"foo_bar"}},{"id":"foo_bar/1","key":"foo_bar","value":1,"doc":{"_id":"foo_bar/1","_rev":"4d33cea0e55142c9ecc6a81600095469","foo":"Foo A","bar":"Bar A","type":"foo_bar"}}]}'
-    @collection = Dolly::Collection.new @json, FooBar
+    @collection = Dolly::Collection.new JSON.parse(@json), FooBar
   end
 
   test 'each returns nil' do
@@ -44,7 +44,7 @@ class CollectionTest < ActiveSupport::TestCase
 
   test 'update empty attributes' do
     json = '{"total_rows":2,"offset":0,"rows":[{"id":"foo_bar/0","key":"foo_bar","value":1,"doc":{"_id":"foo_bar/0","_rev":"7f66379ac92eb6dfafa50c94bd795122","foo":null,"bar":"","type":"foo_bar"}},{"id":"foo_bar/1","key":"foo_bar","value":1,"doc":{"_id":"foo_bar/1","_rev":"4d33cea0e55142c9ecc6a81600095469","foo":"Foo A","bar":"Bar A","type":"foo_bar"}}]}'
-    collection = Dolly::Collection.new json, FooBar
+    collection = Dolly::Collection.new JSON.parse(json), FooBar
 
     collection.update_properties! foo: 'Foo 4 All', bar: 'stuff'
     assert_equal ['Foo 4 All', 'Foo 4 All'], collection.map(&:foo)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ class ActiveSupport::TestCase
     FakeWeb.allow_net_connect = false
 
     response = { uuids: [SecureRandom.uuid] }
-    FakeWeb.register_uri(:get, %r|http://.*:5984/_uuids.*|, body: response.to_json)
+    FakeWeb.register_uri(:get, %r|http://.*:5984/_uuids.*|, body: response.to_json, content_type: 'application/json', accept: 'application/json')
   end
 
   protected


### PR DESCRIPTION
This is the first PR to make Dolly compatible with 2.0
And actually this is the minimal to make it work.
This is fixing the crash due to fix on httparty response handle of couchdb 2.0 requests which now inckude proper headers to accept them as json.