### PR TITLE
Feature/mango indexing

### DIFF
--- a/lib/dolly.rb
+++ b/lib/dolly.rb
@@ -1,5 +1,6 @@
 require "dolly/version"
 require "dolly/document"
+require 'dolly/mango_index'
 require 'railties/railtie' if defined?(Rails)
 
 module Dolly

--- a/lib/dolly/connection.rb
+++ b/lib/dolly/connection.rb
@@ -37,6 +37,10 @@ module Dolly
       request :delete, resource.cgi_escape, query: { rev: rev }
     end
 
+    def delete_index resource
+      request :delete, resource
+    end
+
     def view resource, opts
       request :get, resource, query: values_to_json({include_docs: true}.merge!(opts))
     end

--- a/lib/dolly/document.rb
+++ b/lib/dolly/document.rb
@@ -1,4 +1,5 @@
 require 'dolly/mango'
+require 'dolly/mango_index'
 require 'dolly/query'
 require 'dolly/connection'
 require 'dolly/request'

--- a/lib/dolly/exceptions.rb
+++ b/lib/dolly/exceptions.rb
@@ -25,6 +25,7 @@ module Dolly
     end
   end
 
+  class IndexNotFoundError < RuntimeError; end
   class InvalidConfigFileError < RuntimeError; end
   class InvalidProperty < RuntimeError; end
   class DocumentInvalidError < RuntimeError; end

--- a/lib/dolly/mango_index.rb
+++ b/lib/dolly/mango_index.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'dolly/document'
+
+module Dolly
+  class MangoIndex
+    class << self
+      DESIGN = '_index'
+
+      def all
+        Dolly::Document.connection.get(DESIGN)[:indexes]
+      end
+
+      def create(name, fields, type = 'json')
+        Dolly::Document.connection.post(DESIGN, build_index_structure(name, fields, type))
+      end
+
+      def find_by_fields(fields)
+        all.find do |index_doc|
+          index_doc.dig(:def, :fields).map(&:keys).flatten == fields
+        end
+      end
+
+      def delete_all
+        all.each do |index_doc|
+          delete(index_doc)
+        end
+      end
+
+      private
+
+      def build_index_structure(name, fields, type)
+        {
+          index: {
+            fields: fields
+          },
+          name: name,
+          type: type
+        }
+      end
+    end
+  end
+end

--- a/lib/dolly/mango_index.rb
+++ b/lib/dolly/mango_index.rb
@@ -23,8 +23,15 @@ module Dolly
 
       def delete_all
         all.each do |index_doc|
+          next if index_doc[:ddoc].nil?
           delete(index_doc)
         end
+      end
+
+      def delete(index_doc)
+        resource = "#{DESIGN}/#{index_doc[:ddoc]}/json/#{index_doc[:name]}"
+
+        Dolly::Document.connection.delete_index(resource)
       end
 
       private

--- a/lib/refinements/hash_refinements.rb
+++ b/lib/refinements/hash_refinements.rb
@@ -9,6 +9,18 @@ module HashRefinements
       keys.each_with_object(Hash.new) { |k, hash| hash[k] = self[k] if has_key?(k) }
     end
 
+    # File 'lib/github_api/core_ext/hash.rb', line 54
+    def deep_keys
+      keys = self.keys
+      keys.each do |key|
+        if self[key].is_a?(Hash)
+          keys << self[key].deep_keys.compact.flatten
+          next
+        end
+      end
+      keys.flatten
+    end
+
     private
 
     def _deep_transform_keys_in_object(object, &block)

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -59,5 +59,17 @@ namespace :db do
     end
   end
 
+  namespace :index do
+    desc "Creates indexes for mango querys located in db/indexes/*.json"
+    task create: :environment do
+      indexes_dir = Rails.root.join('db', 'indexes')
+      files = Dir.glob File.join(indexes_dir, '**', '*.json')
+
+      files.each do |file|
+        index_data = JSON.parse(File.read(file))
+        Dolly::MangoIndex.create(index_data['name'], index_data['fields'])
+      end
+    end
+  end
 end
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :db do
   desc "Will create if missing database and add default views"
   task setup: :environment do
@@ -60,7 +62,7 @@ namespace :db do
   end
 
   namespace :index do
-    desc "Creates indexes for mango querys located in db/indexes/*.json"
+    desc 'Creates indexes for mango querys located in db/indexes/*.json'
     task create: :environment do
       indexes_dir = Rails.root.join('db', 'indexes')
       files = Dir.glob File.join(indexes_dir, '**', '*.json')

--- a/test/mango_index_test.rb
+++ b/test/mango_index_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+
+class FooBar < BaseDolly
+  property :foo, :bar
+  property :with_default, default: 1
+  property :boolean, class_name: TrueClass, default: true
+  property :date, class_name: Date
+  property :time, class_name: Time
+  property :datetime, class_name: DateTime
+  property :is_nil, class_name: NilClass, default: nil
+
+  timestamps!
+end
+
+class MangoIndexTest < Test::Unit::TestCase
+  DB_BASE_PATH = "http://localhost:5984/test".freeze
+
+  def setup
+    stub_request(:get, index_base_path).
+      to_return(body: { indexes:[ {
+        ddoc: nil,
+        name:"_all_docs",
+        type:"special",
+        def:{ fields:[{ _id:"asc" }] }
+      },
+      {
+        ddoc: "_design/1",
+        name:"foo-index-json",
+        type:"json",
+        def:{ fields:[{ foo:"asc" }] }
+      }
+    ]}.to_json)
+  end
+
+  test '#delete_all' do
+    previous_indexes = Dolly::MangoIndex.all
+
+    stub_request(:delete, index_delete_path(previous_indexes.last)).
+      to_return(body: { "ok": true }.to_json)
+
+    Dolly::MangoIndex.delete_all
+
+    stub_request(:get, index_base_path).
+      to_return(body: { indexes:[ {
+        ddoc: nil,
+        name:"_all_docs",
+        type:"special",
+        def:{ fields:[{ _id:"asc" }] }
+      }
+    ]}.to_json)
+
+    new_indexes = Dolly::MangoIndex.all
+    assert_not_equal(new_indexes.length, previous_indexes.length)
+    assert_equal(new_indexes.length, 1)
+  end
+
+  def index_base_path
+    "#{DB_BASE_PATH}/_index"
+  end
+
+  def index_delete_path(doc)
+    "#{index_base_path}/#{doc[:ddoc]}/json/#{doc[:name]}"
+  end
+end


### PR DESCRIPTION
Adds public api to create indexes for querys and adds check for methods `find_by` and `where` to verify an index exists for the given query properties
## Example

```
User.find_by(username: 'username')
=> Dolly::IndexNotFoundError (Dolly::IndexNotFoundError)

Dolly::MangoIndex.create('username-json-index', ['username'])
=> {:result=>"created", :id=>"_design/4fd61cc70e6ddc6a4f416938008165c5609f49e9", :name=>"username-json-index"}

User.find_by(username: 'username')
# index takes around 4 minutes to build on the av database with 2575233 documents you can see the progress in http://127.0.0.1:5984/_utils/#/activetasks
=> #<User:0x00007fb5fbe0ac00 @doc={:_id=>"user/+04diego@gmail.com", :username=>"ErickFabian", :email=>"+04diego@gmail.com", :first_name=>"Diego", :last_name=>"Torres"}, @username="ErickFabian", @email="+04diego@gmail.com", @first_name="Diego", @last_name="Torres">

```
## Public Api

```
Dolly::MangoIndex.create(index_name: String, fields: Array, type: String(default: 'json'))
=> Creates an index given for the fields passed

Dolly::MangoIndex.all
=> Returns an array of all the indexes

Dolly::MangoIndex.find_by_fields(fields: Array(symbols))
=> Tries to find an index for the given array of symbols

Dolly::MangoIndex.delete_all
=> Deletes all the indexes created but skips the special index for id's that is created by default

Dolly::MangoIndex.delete(index_doc)
=> Deletes the given index document
```
