### PR TITLE
Use doc type rather than type to avoid errors

### DIFF
--- a/lib/dolly/document_state.rb
+++ b/lib/dolly/document_state.rb
@@ -6,7 +6,7 @@ module Dolly
 
     def save(options = {})
       return false unless options[:validate] == false || valid?
-      set_type if typed? && type.nil?
+      set_type if typed? && doc_type.nil?
       write_timestamps(persisted?)
       after_save(connection.put(id, doc))
     end

--- a/lib/dolly/document_type.rb
+++ b/lib/dolly/document_type.rb
@@ -26,12 +26,12 @@ module Dolly
     end
 
     def typed?
-      respond_to?(:type)
+      respond_to?(:doc_type)
     end
 
     def set_type
       return unless typed?
-      write_attribute(:type, name_paramitized)
+      write_attribute(:doc_type, name_paramitized)
     end
 
     def self.included(base)
@@ -40,7 +40,7 @@ module Dolly
 
     module ClassMethods
       def typed_model
-        property :type, class_name: String
+        property :doc_type, class_name: String
       end
     end
   end

--- a/lib/dolly/mango.rb
+++ b/lib/dolly/mango.rb
@@ -95,8 +95,16 @@ module Dolly
     end
 
     def fetch_fields(query)
-      query.deep_keys.reject do |key|
+      deep_keys(query).reject do |key|
         is_operator?(key)
+      end
+    end
+
+    def deep_keys(obj)
+      case obj
+      when Hash then obj.keys + obj.values.flat_map { |v| deep_keys(v) }
+      when Array then obj.flat_map { |i| deep_keys(i) }
+      else []
       end
     end
   end

--- a/lib/dolly/properties.rb
+++ b/lib/dolly/properties.rb
@@ -4,9 +4,12 @@ require  'dolly/property'
 module Dolly
   module Properties
     SPECIAL_KEYS = %i[_id _rev]
+    INVALID_PROPS = %i[type]
 
     def property *opts, class_name: nil, default: nil
       opts.each do |opt|
+        raise Dolly::InvalidProperty if INVALID_PROPS.include?(opt)
+
         properties << (prop = Property.new(opt, class_name, default))
         send(:attr_reader, opt)
 

--- a/lib/refinements/hash_refinements.rb
+++ b/lib/refinements/hash_refinements.rb
@@ -9,18 +9,6 @@ module HashRefinements
       keys.each_with_object(Hash.new) { |k, hash| hash[k] = self[k] if has_key?(k) }
     end
 
-    # File 'lib/github_api/core_ext/hash.rb', line 54
-    def deep_keys
-      keys = self.keys
-      keys.each do |key|
-        if self[key].is_a?(Hash)
-          keys << self[key].deep_keys.compact.flatten
-          next
-        end
-      end
-      keys.flatten
-    end
-
     private
 
     def _deep_transform_keys_in_object(object, &block)

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -69,7 +69,8 @@ namespace :db do
 
       files.each do |file|
         index_data = JSON.parse(File.read(file))
-        Dolly::MangoIndex.create(index_data['name'], index_data['fields'])
+        puts "Creating index: #{index_data["name"]}"
+        puts Dolly::MangoIndex.create(index_data['name'], index_data['fields'])
       end
     end
   end

--- a/test/document_type_test.rb
+++ b/test/document_type_test.rb
@@ -14,15 +14,23 @@ class DocumentTypeTest < Test::Unit::TestCase
   end
 
   test 'typed_model' do
-    assert_equal(TypedDoc.new.type, nil)
-    assert_equal(UntypedDoc.new.respond_to?(:type), false)
+    assert_equal(TypedDoc.new.doc_type, nil)
+    assert_equal(UntypedDoc.new.respond_to?(:doc_type), false)
     assert_raise NoMethodError do
-      UntypedDoc.new.type
+      UntypedDoc.new.doc_type
     end
   end
 
   test 'set_type' do
     assert_equal(TypedDoc.new.set_type, TypedDoc.name_paramitized)
     assert_equal(UntypedDoc.new.set_type, nil)
+  end
+
+  test 'using prop type' do
+    assert_raise Dolly::InvalidProperty do
+      class TypedTypeDoc < Dolly::Document
+        property :type
+      end
+    end
   end
 end

--- a/test/inheritance_test.rb
+++ b/test/inheritance_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class BaseDoc < Dolly::Document
-  property :type
+  typed_model
 end
 
 class BaseBaseDoc < BaseDoc
@@ -14,10 +14,10 @@ end
 
 class InheritanceTest < Test::Unit::TestCase
   test 'property inheritance' do
-    assert_equal(BaseBaseDoc.new.properties.map(&:key), [:supertype, :type])
+    assert_equal(BaseBaseDoc.new.properties.map(&:key), [:supertype, :doc_type])
   end
 
   test 'deep properties inheritance' do
-    assert_equal(NewBar.new.properties.map(&:key), [:a, :b, :supertype, :type])
+    assert_equal(NewBar.new.properties.map(&:key), [:a, :b, :supertype, :doc_type])
   end
 end


### PR DESCRIPTION
`type` is a mango operator so using it as a prop for a document causes issues

raises an error if `type` is used as a property