### PR TITLE
Normalize method calls to delete documents

### DIFF
--- a/lib/dolly/connection.rb
+++ b/lib/dolly/connection.rb
@@ -33,7 +33,7 @@ module Dolly
       request :put, resource.cgi_escape, data
     end
 
-    def delete resource, rev= nil, escape: true
+    def delete resource, rev = nil, escape: true
       query = { query: { rev: rev } } if rev
       resource = resource.cgi_escape if escape
       request :delete, resource, query

--- a/lib/dolly/connection.rb
+++ b/lib/dolly/connection.rb
@@ -33,12 +33,10 @@ module Dolly
       request :put, resource.cgi_escape, data
     end
 
-    def delete resource, rev
-      request :delete, resource.cgi_escape, query: { rev: rev }
-    end
-
-    def delete_index resource
-      request :delete, resource
+    def delete resource, rev= nil, escape: true
+      query = { query: { rev: rev } } if rev
+      resource = resource.cgi_escape if escape
+      request :delete, resource, query
     end
 
     def view resource, opts
@@ -62,8 +60,8 @@ module Dolly
     end
 
     def request(method, resource, data = {})
-      headers  = Dolly::HeaderRequest.new data.delete(:headers)
-      uri      = build_uri(resource, data.delete(:query))
+      headers  = Dolly::HeaderRequest.new data&.delete(:headers)
+      uri      = build_uri(resource, data&.delete(:query))
       klass    = request_method(method)
       req      = klass.new(uri, headers)
       req.body = format_data(data, headers.json?)

--- a/lib/dolly/mango_index.rb
+++ b/lib/dolly/mango_index.rb
@@ -10,7 +10,7 @@ module Dolly
 
       DESIGN = '_index'
 
-      def_delegators :connection, :get, :post, :delete_index
+      def_delegators :connection, :get, :post
 
       def all
         get(DESIGN)[:indexes]
@@ -35,8 +35,7 @@ module Dolly
 
       def delete(index_doc)
         resource = "#{DESIGN}/#{index_doc[:ddoc]}/json/#{index_doc[:name]}"
-
-        delete_index(resource)
+        connection.delete(resource, escape: false)
       end
 
       private


### PR DESCRIPTION
Normalizes `delete` method to accept docs to be deleted that dont have `revs` (such as databases) and normalizes the way mango indexes are deleted to have a better public interface