### PR TITLE
Use query for index find

### DIFF
--- a/lib/dolly/mango_index.rb
+++ b/lib/dolly/mango_index.rb
@@ -8,7 +8,9 @@ module Dolly
     class << self
       extend Forwardable
 
+      ALL_DOCS = '_all_docs'
       DESIGN = '_index'
+      ROWS_KEY = :rows
 
       def_delegators :connection, :get, :post
 
@@ -21,9 +23,8 @@ module Dolly
       end
 
       def find_by_fields(fields)
-        all.find do |index_doc|
-          index_doc.dig(:def, :fields).map(&:keys).flatten == fields
-        end
+        rows = get(ALL_DOCS, key: key_from_fields(fields))[ROWS_KEY]
+        rows && !rows.empty?
       end
 
       def delete_all
@@ -46,12 +47,17 @@ module Dolly
 
       def build_index_structure(name, fields, type)
         {
+          ddoc: key_from_fields(feilds),
           index: {
             fields: fields
           },
           name: name,
           type: type
         }
+      end
+
+      def key_from_fields(fields)
+        "index_#{fields.join('_')}"
       end
     end
   end

--- a/test/mango_test.rb
+++ b/test/mango_test.rb
@@ -33,20 +33,21 @@ class MangoTest < Test::Unit::TestCase
     stub_request(:get, "#{query_base_path}?startkey=%22foo_bar%2F%22&endkey=%22foo_bar%2F%EF%BF%B0%22&include_docs=true").
       to_return(body: @multi_resp.to_json)
 
-    stub_request(:get, index_base_path).
-      to_return(body: { indexes:[ {
-        ddoc: nil,
-        name:"_all_docs",
-        type:"special",
-        def:{ fields:[{ _id:"asc" }] }
-      },
-      {
-        ddoc: "_design/1",
-        name:"foo-index-json",
-        type:"json",
-        def:{ fields:[{ foo:"asc" }] }
-      }
-    ]}.to_json)
+    stub_request(:get, "#{all_docs_path}?key=\"index_foo\"").
+      to_return(body: {
+        total_rows: 2,
+        offset: 0,
+        rows: [{
+          id: '_design/index_foo',
+          key: '_design/index_foo',
+          value: { rev: '1-c5457a0d26da85f15c4ad6bd739e441d' }
+        }]}.to_json)
+
+    stub_request(:get, "#{all_docs_path}?key=\"index_date\"").
+      to_return(body: {
+        total_rows: 2,
+        offset: 0,
+        rows: []}.to_json)
   end
 
   test '#find_by' do
@@ -196,8 +197,8 @@ class MangoTest < Test::Unit::TestCase
     "#{DB_BASE_PATH}/_find"
   end
 
-  def index_base_path
-    "#{DB_BASE_PATH}/_index"
+  def all_docs_path
+    "#{DB_BASE_PATH}/_all_docs"
   end
 
   def build_save_request(obj)


### PR DESCRIPTION
Doing a find all, and then filter on Ruby can have performance issues, once there is more index files, this PR changes to use a find by id on the requested index.

It also create a pre-deterministic doc id for Mango indexes.