### PR TITLE
Add back type to dolly document

### DIFF
--- a/lib/dolly/document_state.rb
+++ b/lib/dolly/document_state.rb
@@ -6,7 +6,7 @@ module Dolly
 
     def save(options = {})
       return false unless options[:validate] == false || valid?
-      set_type if typed? && doc_type.nil?
+      set_type if typed? && type.nil?
       write_timestamps(persisted?)
       after_save(connection.put(id, doc))
     end

--- a/lib/dolly/document_type.rb
+++ b/lib/dolly/document_type.rb
@@ -26,12 +26,12 @@ module Dolly
     end
 
     def typed?
-      respond_to?(:doc_type)
+      respond_to?(:type)
     end
 
     def set_type
       return unless typed?
-      write_attribute(:doc_type, name_paramitized)
+      write_attribute(:type, name_paramitized)
     end
 
     def self.included(base)
@@ -40,7 +40,7 @@ module Dolly
 
     module ClassMethods
       def typed_model
-        property :doc_type, class_name: String
+        property :type, class_name: String
       end
     end
   end

--- a/lib/dolly/properties.rb
+++ b/lib/dolly/properties.rb
@@ -4,11 +4,9 @@ require  'dolly/property'
 module Dolly
   module Properties
     SPECIAL_KEYS = %i[_id _rev]
-    INVALID_PROPS = %i[type]
 
     def property *opts, class_name: nil, default: nil
       opts.each do |opt|
-        raise Dolly::InvalidProperty if INVALID_PROPS.include?(opt)
 
         properties << (prop = Property.new(opt, class_name, default))
         send(:attr_reader, opt)

--- a/test/document_type_test.rb
+++ b/test/document_type_test.rb
@@ -14,23 +14,15 @@ class DocumentTypeTest < Test::Unit::TestCase
   end
 
   test 'typed_model' do
-    assert_equal(TypedDoc.new.doc_type, nil)
-    assert_equal(UntypedDoc.new.respond_to?(:doc_type), false)
+    assert_equal(TypedDoc.new.type, nil)
+    assert_equal(UntypedDoc.new.respond_to?(:type), false)
     assert_raise NoMethodError do
-      UntypedDoc.new.doc_type
+      UntypedDoc.new.type
     end
   end
 
   test 'set_type' do
     assert_equal(TypedDoc.new.set_type, TypedDoc.name_paramitized)
     assert_equal(UntypedDoc.new.set_type, nil)
-  end
-
-  test 'using prop type' do
-    assert_raise Dolly::InvalidProperty do
-      class TypedTypeDoc < Dolly::Document
-        property :type
-      end
-    end
   end
 end

--- a/test/inheritance_test.rb
+++ b/test/inheritance_test.rb
@@ -14,10 +14,10 @@ end
 
 class InheritanceTest < Test::Unit::TestCase
   test 'property inheritance' do
-    assert_equal(BaseBaseDoc.new.properties.map(&:key), [:supertype, :doc_type])
+    assert_equal(BaseBaseDoc.new.properties.map(&:key), [:supertype, :type])
   end
 
   test 'deep properties inheritance' do
-    assert_equal(NewBar.new.properties.map(&:key), [:a, :b, :supertype, :doc_type])
+    assert_equal(NewBar.new.properties.map(&:key), [:a, :b, :supertype, :type])
   end
 end


### PR DESCRIPTION
Adds back type property for documents, handling `type` as an operator for mango querys will be handled in a separate PR