### PR TITLE
Feature/type mango query

### DIFF
--- a/lib/dolly/document_state.rb
+++ b/lib/dolly/document_state.rb
@@ -6,7 +6,7 @@ module Dolly
 
     def save(options = {})
       return false unless options[:validate] == false || valid?
-      set_type if typed? && doc_type.nil?
+      set_type if typed? && type.nil?
       write_timestamps(persisted?)
       after_save(connection.put(id, doc))
     end

--- a/lib/dolly/document_type.rb
+++ b/lib/dolly/document_type.rb
@@ -26,12 +26,12 @@ module Dolly
     end
 
     def typed?
-      respond_to?(:doc_type)
+      respond_to?(:type)
     end
 
     def set_type
       return unless typed?
-      write_attribute(:doc_type, name_paramitized)
+      write_attribute(:type, name_paramitized)
     end
 
     def self.included(base)
@@ -40,7 +40,7 @@ module Dolly
 
     module ClassMethods
       def typed_model
-        property :doc_type, class_name: String
+        property :type, class_name: String
       end
     end
   end

--- a/lib/dolly/mango.rb
+++ b/lib/dolly/mango.rb
@@ -26,13 +26,17 @@ module Dolly
       gte
       gt
       exists
-      type
       in
       nin
       size
       mod
       regex
     ].freeze
+
+    TYPE_OPERATOR = %I[
+      type
+      $type
+    ]
 
     ALL_OPERATORS = COMBINATION_OPERATORS + CONDITION_OPERATORS
 
@@ -77,7 +81,8 @@ module Dolly
     def build_selectors(query)
       query.deep_transform_keys do |key|
         next build_key(key) if is_operator?(key)
-        raise Dolly::InvalidMangoOperatorError.new(key) unless self.all_property_keys.include?(key)
+        next key if is_type_operator?(key)
+        raise Dolly::InvalidMangoOperatorError.new(key) unless has_property?(key)
         key
       end
     end
@@ -96,8 +101,16 @@ module Dolly
 
     def fetch_fields(query)
       deep_keys(query).reject do |key|
-        is_operator?(key)
+        is_operator?(key) || is_type_operator?(key)
       end
+    end
+
+    def has_property?(key)
+      self.all_property_keys.include?(key)
+    end
+
+    def is_type_operator?(key)
+      TYPE_OPERATOR.include?(key)
     end
 
     def deep_keys(obj)

--- a/lib/dolly/mango.rb
+++ b/lib/dolly/mango.rb
@@ -110,7 +110,7 @@ module Dolly
     end
 
     def is_type_operator?(key)
-      TYPE_OPERATOR.include?(key)
+      TYPE_OPERATOR.include?(key.to_sym)
     end
 
     def deep_keys(obj)

--- a/lib/dolly/mango_index.rb
+++ b/lib/dolly/mango_index.rb
@@ -11,6 +11,7 @@ module Dolly
       ALL_DOCS = '_all_docs'
       DESIGN = '_index'
       ROWS_KEY = :rows
+      DESIGN_PREFIX = '_design/'
 
       def_delegators :connection, :get, :post
 
@@ -24,7 +25,7 @@ module Dolly
 
       def find_by_fields(fields)
         rows = get(ALL_DOCS, key: key_from_fields(fields))[ROWS_KEY]
-        rows && !rows.empty?
+        rows && rows.any?
       end
 
       def delete_all
@@ -47,7 +48,7 @@ module Dolly
 
       def build_index_structure(name, fields, type)
         {
-          ddoc: key_from_fields(feilds),
+          ddoc: key_from_fields(fields).gsub(DESIGN_PREFIX, ''),
           index: {
             fields: fields
           },
@@ -57,7 +58,7 @@ module Dolly
       end
 
       def key_from_fields(fields)
-        "index_#{fields.join('_')}"
+        "#{DESIGN_PREFIX}index_#{fields.join('_')}"
       end
     end
   end

--- a/lib/dolly/properties.rb
+++ b/lib/dolly/properties.rb
@@ -4,11 +4,9 @@ require  'dolly/property'
 module Dolly
   module Properties
     SPECIAL_KEYS = %i[_id _rev]
-    INVALID_PROPS = %i[type]
 
     def property *opts, class_name: nil, default: nil
       opts.each do |opt|
-        raise Dolly::InvalidProperty if INVALID_PROPS.include?(opt)
 
         properties << (prop = Property.new(opt, class_name, default))
         send(:attr_reader, opt)

--- a/test/document_type_test.rb
+++ b/test/document_type_test.rb
@@ -14,23 +14,15 @@ class DocumentTypeTest < Test::Unit::TestCase
   end
 
   test 'typed_model' do
-    assert_equal(TypedDoc.new.doc_type, nil)
-    assert_equal(UntypedDoc.new.respond_to?(:doc_type), false)
+    assert_equal(TypedDoc.new.type, nil)
+    assert_equal(UntypedDoc.new.respond_to?(:type), false)
     assert_raise NoMethodError do
-      UntypedDoc.new.doc_type
+      UntypedDoc.new.type
     end
   end
 
   test 'set_type' do
     assert_equal(TypedDoc.new.set_type, TypedDoc.name_paramitized)
     assert_equal(UntypedDoc.new.set_type, nil)
-  end
-
-  test 'using prop type' do
-    assert_raise Dolly::InvalidProperty do
-      class TypedTypeDoc < Dolly::Document
-        property :type
-      end
-    end
   end
 end

--- a/test/inheritance_test.rb
+++ b/test/inheritance_test.rb
@@ -14,10 +14,10 @@ end
 
 class InheritanceTest < Test::Unit::TestCase
   test 'property inheritance' do
-    assert_equal(BaseBaseDoc.new.properties.map(&:key), [:supertype, :doc_type])
+    assert_equal(BaseBaseDoc.new.properties.map(&:key), [:supertype, :type])
   end
 
   test 'deep properties inheritance' do
-    assert_equal(NewBar.new.properties.map(&:key), [:a, :b, :supertype, :doc_type])
+    assert_equal(NewBar.new.properties.map(&:key), [:a, :b, :supertype, :type])
   end
 end

--- a/test/mango_test.rb
+++ b/test/mango_test.rb
@@ -12,6 +12,10 @@ class FooBar < BaseDolly
   timestamps!
 end
 
+class FooBarTyped < BaseDolly
+  typed_model
+end
+
 class MangoTest < Test::Unit::TestCase
   DB_BASE_PATH = "http://localhost:5984/test".freeze
 
@@ -57,15 +61,23 @@ class MangoTest < Test::Unit::TestCase
     stub_request(:post, query_base_path).
      to_return(body: resp.to_json)
 
+    key = 'foo'
+    stub_request(:get, "#{all_docs_path}?key=\"_design/index_#{key}\"").
+     to_return(body: index_response(key).to_json)
+
     assert_equal(FooBar.find_by(foo: 'bar').class, FooBar)
   end
 
   test '#find_by for a property that does not have an index' do
     #TODO: clean up all the fake request creation
     resp = { docs: [{ foo: 'bar', id: "foo_bar/1"} ] }
+    key = 'date'
 
     stub_request(:post, query_base_path).
      to_return(body: resp.to_json)
+
+    stub_request(:get, "#{all_docs_path}?key=\"_design/index_#{key}\"").
+     to_return(body: { rows: [] }.to_json)
 
     assert_raise Dolly::IndexNotFoundError do
       FooBar.find_by(date: Date.today)
@@ -78,6 +90,10 @@ class MangoTest < Test::Unit::TestCase
     stub_request(:post, query_base_path).
      to_return(body: resp.to_json)
 
+    key = 'foo'
+    stub_request(:get, "#{all_docs_path}?key=\"_design/index_#{key}\"").
+     to_return(body: index_response(key).to_json)
+
     assert_equal(FooBar.find_by(foo: 'bar'), nil)
   end
 
@@ -87,6 +103,10 @@ class MangoTest < Test::Unit::TestCase
 
     stub_request(:post, query_base_path).
      to_return(body: resp.to_json)
+
+    key = 'foo'
+    stub_request(:get, "#{all_docs_path}?key=\"_design/index_#{key}\"").
+     to_return(body: index_response(key).to_json)
 
     assert_equal(FooBar.find_doc_by(foo: 'bar').class, Hash)
   end
@@ -98,6 +118,10 @@ class MangoTest < Test::Unit::TestCase
     stub_request(:post, query_base_path).
      to_return(body: resp.to_json)
 
+    key = 'foo'
+    stub_request(:get, "#{all_docs_path}?key=\"_design/index_#{key}\"").
+     to_return(body: index_response(key).to_json)
+
     assert_equal(FooBar.where(foo: { eq: 'bar' }).map(&:class).uniq, [FooBar])
   end
 
@@ -107,6 +131,10 @@ class MangoTest < Test::Unit::TestCase
 
     stub_request(:post, query_base_path).
      to_return(body: resp.to_json)
+
+    key = 'date'
+    stub_request(:get, "#{all_docs_path}?key=\"_design/index_#{key}\"").
+     to_return(body: { rows: [] }.to_json)
 
     assert_raise Dolly::IndexNotFoundError do
       FooBar.where(date: Date.today)
@@ -119,6 +147,10 @@ class MangoTest < Test::Unit::TestCase
     stub_request(:post, query_base_path).
      to_return(body: resp.to_json)
 
+    key = 'foo'
+    stub_request(:get, "#{all_docs_path}?key=\"_design/index_#{key}\"").
+     to_return(body: index_response(key).to_json)
+
     assert_equal(FooBar.where(foo: 'bar'), [])
   end
 
@@ -128,6 +160,10 @@ class MangoTest < Test::Unit::TestCase
 
     stub_request(:post, query_base_path).
      to_return(body: resp.to_json)
+
+    key = 'foo'
+    stub_request(:get, "#{all_docs_path}?key=\"_design/index_#{key}\"").
+     to_return(body: index_response(key).to_json)
 
     assert_equal(FooBar.docs_where(foo: { eq: 'bar' }).map(&:class).uniq, [Hash])
   end
@@ -156,7 +192,24 @@ class MangoTest < Test::Unit::TestCase
     end
   end
 
+  test '#build_selectors with type operator' do
+    query = { _id: { type: "user" } }
+
+    assert_nothing_raised Dolly::InvalidMangoOperatorError do
+      FooBarTyped.send(:build_selectors, query)
+    end
+  end
+
+  test '#build_selectors with $type operator' do
+    query = { _id: { "$type" => "null" } }
+
+    assert_nothing_raised Dolly::InvalidMangoOperatorError do
+      FooBarTyped.send(:build_selectors, query)
+    end
+  end
+
   private
+
   def generic_response rows, count = 1
     {total_rows: count, offset:0, rows: rows}
   end
@@ -204,5 +257,17 @@ class MangoTest < Test::Unit::TestCase
   def build_save_request(obj)
     stub_request(:put, "#{DB_BASE_PATH}/#{CGI.escape(obj.id)}").
       to_return(body: {ok: true, id: obj.id, rev: "FF0000" }.to_json)
+  end
+
+  def index_response(key)
+    {
+      rows: [
+        {
+          id: "_design/index_#{key}",
+          key: "_design/index_#{key}",
+          value: { rev: '1-c5457a0d26da85f15c4ad6bd739e441d' }
+        }
+      ]
+    }
   end
 end


### PR DESCRIPTION
Enables querys such as: 
`query = {and: [{ type: { eq: 'user' } } , { username: { eq: 'ErickFabian'}} ]}`
`User.where(query)`
=> `[....]`

and

`User.where({username: { "$type": "null"}})`