### PR TITLE
adding support to NET HTTP response for HEAD

### DIFF
--- a/lib/dolly/bulk_document.rb
+++ b/lib/dolly/bulk_document.rb
@@ -80,7 +80,7 @@ module Dolly
     end
 
     def response_error(item)
-      BulkError.new(error: 'Document saved but not local rev updated.', reason: "Document with id #{doc['id']} on bulk doc was not found in payload.", obj: nil)
+      BulkError.new(error: 'Document saved but not local rev updated.', reason: "Document with id #{item} on bulk doc was not found in payload.", obj: nil)
     end
   end
 end

--- a/lib/dolly/connection.rb
+++ b/lib/dolly/connection.rb
@@ -67,7 +67,7 @@ module Dolly
       req.body = format_data(data, headers.json?)
       response = start_request(req)
 
-      response_format(response)
+      response_format(response, method)
     end
 
     private
@@ -79,9 +79,10 @@ module Dolly
       end
     end
 
-    def response_format(res)
+    def response_format(res, method)
       raise Dolly::ResourceNotFound if res.code.to_i == 404
       raise Dolly::ServerError.new(res.body) if (400..600).include? res.code.to_i
+      return res if method == :head
       Oj.load(res.body, symbol_keys: true)
     end
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -42,7 +42,7 @@ namespace :db do
       begin
         hash_doc = Dolly::Document.connection.request(:get, view_doc["_id"])
 
-        rev = hash_doc.delete('_rev')
+        rev = hash_doc.delete(:_rev)
 
         if hash_doc == view_doc
           puts 'everything up to date'


### PR DESCRIPTION
* HEAD request response varies from HTTP Party, so we need to handle it.
* Delete method had a wrong call to string key instead of new symbol keys