### PR TITLE
Rename db namespace method to avoid clashes

### DIFF
--- a/lib/dolly/collection.rb
+++ b/lib/dolly/collection.rb
@@ -6,6 +6,7 @@ module Dolly
       @options = options
       #TODO: We should raise an exception if one of the
       #      requested documents is missing
+
       super rows[:rows].map(&collect_docs).compact
     end
 

--- a/lib/dolly/collection.rb
+++ b/lib/dolly/collection.rb
@@ -6,7 +6,6 @@ module Dolly
       @options = options
       #TODO: We should raise an exception if one of the
       #      requested documents is missing
-
       super rows[:rows].map(&collect_docs).compact
     end
 

--- a/lib/dolly/query.rb
+++ b/lib/dolly/query.rb
@@ -14,8 +14,7 @@ module Dolly
       query_hash = { keys: namespace_keys(keys).map { |k| k.cgi_escape } }
       return [] if query_hash[:keys].none?
 
-      keys_to_find_counter = query_hash[:keys].length
-      build_collection(query_hash).first_or_all(keys_to_find_counter > 1)&.itself ||
+      build_collection(query_hash).first_or_all&.itself ||
         raise(Dolly::ResourceNotFound)
     end
 

--- a/lib/dolly/query.rb
+++ b/lib/dolly/query.rb
@@ -12,7 +12,6 @@ module Dolly
 
     def find *keys
       query_hash = { keys: namespace_keys(keys).map { |k| k.cgi_escape } }
-      return [] if query_hash[:keys].none?
 
       build_collection(query_hash).first_or_all&.itself ||
         raise(Dolly::ResourceNotFound)

--- a/lib/dolly/query.rb
+++ b/lib/dolly/query.rb
@@ -12,9 +12,19 @@ module Dolly
 
     def find *keys
       query_hash = { keys: namespace_keys(keys).map { |k| k.cgi_escape } }
+      return [] if query_hash[:keys].none?
 
-      build_collection(query_hash).first_or_all&.itself ||
+      keys_to_find_counter = query_hash[:keys].length
+      build_collection(query_hash).first_or_all(keys_to_find_counter > 1)&.itself ||
         raise(Dolly::ResourceNotFound)
+    end
+
+    def find_all(*keys)
+      query_hash = { keys: namespace_keys(keys).map { |k| k.cgi_escape } }
+      return [] if query_hash[:keys].none?
+
+      keys_to_find_counter = query_hash[:keys].length
+      build_collection(query_hash).first_or_all(true)&.itself
     end
 
     def safe_find *keys

--- a/lib/dolly/request.rb
+++ b/lib/dolly/request.rb
@@ -1,19 +1,19 @@
 module Dolly
   module Request
-    def set_namespace name
-      @namespace = name
+    def set_db_namespace(name)
+      @_db_namespace = name
     end
 
-    def set_app_env env
+    def set_app_env(env)
       @app_env = env
     end
 
     def connection
-      @connection ||= Connection.new(namespace, app_env)
+      @connection ||= Connection.new(db_namespace, app_env)
     end
 
-    def namespace
-      @namespace ||= :default
+    def db_namespace
+      @_db_namespace ||= :default
     end
 
     def app_env

--- a/lib/dolly/view_query.rb
+++ b/lib/dolly/view_query.rb
@@ -2,13 +2,25 @@ require 'dolly/class_methods_delegation'
 
 module Dolly
   module ViewQuery
-    def raw_view(doc, view_name, opts = {})
-      design = "_design/#{doc}/_view/#{view_name}"
+    def raw_view(design, view_name, opts = {})
+      include_docs = opts.delete(:include_docs)
+      include_docs ||= 'true'
+
+      design = "_design/#{design}/_view/#{view_name}"
       connection.view(design, opts)
     end
 
-    def view_value(doc, view_name, opts = {})
-      raw_view(doc, view_name, opts)[:rows].flat_map { |result| result[:value] }
+    def view_value(design, view_name, opts = {})
+      raw_view(design, view_name, opts)[:rows].flat_map { |result| result[:value] }
+    end
+
+    def collection_view(design, view_name, opts = {})
+      include_docs = opts.delete(:include_docs)
+      include_docs ||= 'true'
+
+      design = "_design/#{design}/_view/#{view_name}"
+      response = connection.view(design, opts)
+      Dolly::Collection.new(rows: response, options: opts)
     end
   end
 end


### PR DESCRIPTION
Refactors set_namespace method to avoid method clashes  and introduces collection_view method into the base methods of a dolly document