### PR TITLE
Symbolize keys in update_properties

### DIFF
--- a/lib/dolly/document_state.rb
+++ b/lib/dolly/document_state.rb
@@ -17,7 +17,7 @@ module Dolly
     end
 
     def update_properties(properties)
-      properties.each(&update_attribute)
+      properties.deep_symbolize_keys.each(&update_attribute)
     end
 
     def update_properties!(properties)


### PR DESCRIPTION
Doing

`user.update_properties!('first_name' => 'erick')`

causes a `Dolly::InvalidProperty` error, which is confusing i think, so to provide a better developer experience i transform the keys to symbols to comply with using symbols and avoid creating string objets