### PR TITLE
Add remote database index creation to index creation task

### DIFF
--- a/lib/dolly/connection.rb
+++ b/lib/dolly/connection.rb
@@ -14,10 +14,11 @@ module Dolly
 
     DEFAULT_HEADER = { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
     SECURE_PROTOCOL = 'https'
+    DEFAULT_DATABASE = :default
 
     using StringRefinements
 
-    def initialize db = :default, app_env = :development
+    def initialize db = DEFAULT_DATABASE, app_env = :development
       @db      = db
       @app_env = app_env
     end

--- a/lib/dolly/mango_index.rb
+++ b/lib/dolly/mango_index.rb
@@ -23,6 +23,10 @@ module Dolly
         post(DESIGN, build_index_structure(name, fields, type))
       end
 
+      def create_in_database(database, name, fields, type = 'json')
+        connection_for_database(database).post(DESIGN, build_index_structure(name, fields, type))
+      end
+
       def find_by_fields(fields)
         rows = get(ALL_DOCS, key: key_from_fields(fields))[ROWS_KEY]
         rows && rows.any?
@@ -41,6 +45,10 @@ module Dolly
       end
 
       private
+
+      def connection_for_database(database)
+        Dolly::Connection.new(database.to_sym, Rails.env || :development)
+      end
 
       def connection
         @connection ||= Dolly::Document.connection

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -69,11 +69,11 @@ namespace :db do
 
       files.each do |file|
         index_data = JSON.parse(File.read(file))
-        database = index_data.fetch('db', 'default')
+        database = index_data.fetch('db', 'default').to_sym
         puts "*" * 100
         puts "Creating index: #{index_data["name"]} for database: #{database}"
 
-        if database == 'default'
+        if database == Dolly::Connection::DEFAULT_DATABASE
           puts Dolly::MangoIndex.create(index_data['name'], index_data['fields'])
         else
           puts Dolly::MangoIndex.create_in_database(database, index_data['name'], index_data['fields'])

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -69,8 +69,15 @@ namespace :db do
 
       files.each do |file|
         index_data = JSON.parse(File.read(file))
-        puts "Creating index: #{index_data["name"]}"
-        puts Dolly::MangoIndex.create(index_data['name'], index_data['fields'])
+        database = index_data.fetch('db', 'default')
+        puts "*" * 100
+        puts "Creating index: #{index_data["name"]} for database: #{database}"
+
+        if database == 'default'
+          puts Dolly::MangoIndex.create(index_data['name'], index_data['fields'])
+        else
+          puts Dolly::MangoIndex.create_in_database(database, index_data['name'], index_data['fields'])
+        end
       end
     end
   end


### PR DESCRIPTION
Allows an application to create indexes specifying a different database example
`amco_sis/db/indexes/bs/legacy_school_id.json`

```
{
  "name" : "grade_subject-grade_code-language-id-json-index",
  "fields": ["legacy_school_id"],
  "db": "bs"
}
```

In this case the `db` key is used to specify which database will have the index created, this is used for models such as `school.rb`

with `set_namespace :bs`

if db is not specified the default database connection is used