### PR TITLE
Use Hash With Indifferent access if available

### DIFF
--- a/lib/dolly/connection.rb
+++ b/lib/dolly/connection.rb
@@ -92,7 +92,12 @@ module Dolly
       raise Dolly::ResourceNotFound if res.status.to_i == 404
       raise Dolly::ServerError.new(res.status.to_i) if (400..600).include? res.status.to_i
       return res.header_str if method == :head
-      Oj.load(res.body_str, symbol_keys: true)
+
+      data = Oj.load(res.body_str, symbol_keys: true)
+      return data unless defined?(ActiveSupport::HashWithIndifferentAccess)
+      data.with_indifferent_access
+    rescue Oj::ParseError
+      res.body_str
     end
 
     def values_to_json hash

--- a/lib/dolly/document_creation.rb
+++ b/lib/dolly/document_creation.rb
@@ -10,7 +10,9 @@ module Dolly
     end
 
     def from_json(json)
-      from_doc(Oj.load(json, symbol_keys: true))
+      raw_data = Oj.load(json, symbol_keys: true)
+      data = defined?(ActiveSupport::HashWithIndifferentAccess) ? data.with_indifferent_access : raw_data
+      from_doc(data)
     end
 
     def create(attributes)

--- a/lib/dolly/properties.rb
+++ b/lib/dolly/properties.rb
@@ -30,7 +30,7 @@ module Dolly
     end
 
     def property_clean_doc(doc)
-      doc.reject { |key, _value| !property_keys.include?(key) }
+      doc.reject { |key, _value| property_keys.exclude?(key.to_sym) }
     end
   end
 end

--- a/lib/dolly/property_manager.rb
+++ b/lib/dolly/property_manager.rb
@@ -5,7 +5,7 @@ module Dolly
       assign_rev_properties(attributes)
 
       lambda do |property|
-        name = property.key.to_sym
+        name = property.key
         next unless doc[name].nil?
         write_attribute(name, attributes[name])
       end


### PR DESCRIPTION
We were not using hash with indifferent access toa void dependency with rails, but it is necessary for rails projects some times, so the doc will be parsed with indifferent access if `active_support/with_indifferent_access` is present.