### PR TITLE
Fix issue with hashes not being indifferent access if available on document property build

### DIFF
--- a/lib/dolly/framework_helper.rb
+++ b/lib/dolly/framework_helper.rb
@@ -1,7 +1,7 @@
 module Dolly
   module FrameworkHelper
     def rails?
-      defined?(ActiveSupport::HashWithIndifferentAccess)
+      !!defined?(ActiveSupport::HashWithIndifferentAccess)
     end
   end
 end

--- a/lib/dolly/property.rb
+++ b/lib/dolly/property.rb
@@ -21,7 +21,7 @@ module Dolly
     end
 
     def custom_class(value)
-      value = value.is_a?(Hash) ? value.symbolize_keys : value
+      value = value.is_a?(Hash) ? hash_with_indifferent_access_value(value) : value
       self_klass.new(value)
     end
 
@@ -34,7 +34,7 @@ module Dolly
     end
 
     def hash_value(value)
-      value.to_h
+      hash_with_indifferent_access_value(value)
     end
 
     def hash_with_indifferent_access_value(value)

--- a/lib/dolly/property_set.rb
+++ b/lib/dolly/property_set.rb
@@ -1,7 +1,7 @@
 module Dolly
   class PropertySet < Set
-    def include? key
-      keys.include?(key)
+    def include?(key)
+      keys.include?(key.to_sym)
     end
 
     def <<(property)
@@ -11,7 +11,7 @@ module Dolly
 
     def [](key)
       return detect {|property| property.key == key } if key.is_a?(Symbol)
-      super
+      detect {|property| property.key.to_s == key }
     end
 
     private


### PR DESCRIPTION
## Previous

```
 s = School.find '456cf976e747389a2f5fedfed005a142'
s.contracts.class
=> Hash
```
## After

```
 s = School.find '456cf976e747389a2f5fedfed005a142'
s.contracts.class
=> ActiveSupport::HashWithIndifferentAccess
```
