### PR TITLE
Handle partitioned databases

### DIFF
--- a/config/couchdb.yml
+++ b/config/couchdb.yml
@@ -16,10 +16,16 @@ travis: &travis
 development:
   default:
     <<: *couchdb
+  partitioned:
+    <<: *couchdb
+    name: partitioned
 
 test:
   default:
     <<: <%= ENV['TRAVIS'] ? "*travis" : "*couchdb" %>
+  partitioned:
+    <<: <%= ENV['TRAVIS'] ? "*travis" : "*couchdb" %>
+    name: partitioned
 
 staging:
   default:

--- a/lib/dolly/exceptions.rb
+++ b/lib/dolly/exceptions.rb
@@ -37,6 +37,7 @@ module Dolly
     end
   end
 
+  class PartitionedDataBaseExpectedError < RuntimeError; end
   class IndexNotFoundError < RuntimeError; end
   class InvalidConfigFileError < RuntimeError; end
   class InvalidProperty < RuntimeError; end

--- a/test/partitioned_document_test.rb
+++ b/test/partitioned_document_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class PartitionedDocumentTest < Test::Unit::TestCase
+  PARTITIONED_DB_PATH = 'http://localhost:5984/partitioned/'
+
+  test 'unpartitioned DB will raise exception' do
+    stub_request(:get, PARTITIONED_DB_PATH).
+      with(headers: { 'Content-Type'=>'application/json' }).
+      to_return(status: 200, body: { db_name: 'partitioned' }.to_json)
+
+    assert_raise(Dolly::PartitionedDataBaseExpectedError) do
+      class Partitioned < Dolly::Document
+        partitioned!
+        property :foo, class_name: String
+      end
+    end
+  end
+
+  test 'document id is partitioned' do
+    stub_request(:get, PARTITIONED_DB_PATH).
+      with(headers: { 'Content-Type'=>'application/json' }).
+      to_return(status: 200, body: { db_name: 'partitioned', props: { partitioned: true } }.to_json)
+
+    class Partitioned < Dolly::Document
+      set_namespace 'partitioned'
+      partitioned!
+
+      property :foo, class_name: String
+    end
+
+    doc = Partitioned.new(foo: "something")
+    assert doc.id =~ /^partitioned:.+/
+  end
+end
+
+


### PR DESCRIPTION
CouchDB  2/3 allows partition databases, using this will allow to have namespaces lookups as fast as main index lookups,

We added a new class method for a Dolly Document such as

```
class MyDocument < Dolly::Document
  partitioned!
end
```

This will change the pattern for `_id` to be `namespace:ID` instead of `namespace/ID`

It will also raise an exception if the DB is not partitioned, so for 1.x will always raise this exception.
The exception will raise when the class is loaded, so depending on the env, can be on app start.