### PR TITLE
Handle empty values with default not being setup

### DIFF
--- a/lib/dolly/property.rb
+++ b/lib/dolly/property.rb
@@ -14,7 +14,7 @@ module Dolly
     end
 
     def cast_value(value)
-      return set_default if value.nil?
+      return set_default if empty_value?(value)
       return value unless class_name
       return custom_class(value) unless respond_to?(klass_sym)
       send(klass_sym, value)
@@ -27,6 +27,11 @@ module Dolly
 
     def boolean?
       [TrueClass, FalseClass].include?(class_name)
+    end
+
+    def empty_value?(value)
+      return value&.empty? if value.respond_to?(:empty?)
+      value.nil?
     end
 
     def string_value(value)

--- a/test/support/property_test.rb
+++ b/test/support/property_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class TestHashDoc < Dolly::Document
+  property :roles, class_name: Hash, default: { teacher: {} }
+end
+
+class TestIntegerDoc < Dolly::Document
+  property :count, class_name: Integer, default: 0
+end
+
+class PropertyTest < Test::Unit::TestCase
+  test 'With a hash property with a default value' do
+    doc = TestHashDoc.new
+    assert_equal(doc.roles, { teacher: {} })
+  end
+
+  test 'With a hash property with an empty value it sets the default value' do
+    doc = TestHashDoc.new(roles: [])
+    assert_equal(doc.roles, { teacher: {} })
+  end
+
+  test 'With a hash property with a previous non empty value it preserves the value' do
+    doc = TestHashDoc.new(roles: { teacher: { 'user/amco@mail.com': {} } })
+    assert_equal(doc.roles, { teacher: { 'user/amco@mail.com': {} } })
+  end
+
+  test 'With an Integer property with a nil value it sets the default value' do
+    doc = TestIntegerDoc.new(count: nil)
+    assert_equal(doc.count, 0)
+  end
+
+  test 'With an Integer property with a previous non empty value it preserves the value' do
+    doc = TestIntegerDoc.new(count: 10)
+    assert_equal(doc.count, 10)
+  end
+end


### PR DESCRIPTION
Properties set with a non nil value would not be overwritten using the default value

```
class Test < Couch::Base
  property :roles, class_name: Hash, default: {teacher: {}, student: {}}
end
```

```
 t3 = Test.find 'test/558d163d26141e5b770516292aa5afec'
=> #<Test:0x00007f9c59b8fc98 @doc={:_id=>"test/558d163d26141e5b770516292aa5afec", :_rev=>"2-8166172731f239617071bf3fe0ef7046", :roles=>{}}, @roles={}>
[27] pry(main)> t3.roles
=> {}
[28] pry(main)> t3.roles[:teacher]
=> nil
```