### PR TITLE
fix truthy wrong return

### DIFF
--- a/lib/dolly/property.rb
+++ b/lib/dolly/property.rb
@@ -80,7 +80,7 @@ module Dolly
 
     def truthy_value?(value)
       value === true ||
-      (value.is_a?(String) && value =~ /true/)
+        (value.is_a?(String) && value.match?(/true/))
     end
 
     def klass_sym

--- a/test/property_manager_test.rb
+++ b/test/property_manager_test.rb
@@ -4,15 +4,17 @@ class TestDoc < Dolly::Document
   property :name, class_name: String
   property :email, class_name: String
   property :last_name, class_name: String
+  property :active, class_name: TrueClass
 end
 
 class PropertyManagerTest < Test::Unit::TestCase
   test 'write_attribute with nil value' do
-    doc = TestDoc.new(name: 'name', last_name: nil, email: 'does not change')
+    doc = TestDoc.new(name: 'name', last_name: nil, email: 'does not change', active: 'true')
     assert_equal(doc.name, 'name')
     doc.update_properties(name: nil)
     assert_equal(doc.name, nil)
     assert_equal(doc.last_name, nil)
     assert_equal(doc.email, 'does not change')
+    assert_equal(doc.active, true)
   end
 end


### PR DESCRIPTION
"true" value is not being casted to `true` on boolean properties.