### PR TITLE
assign objects in a way to keep identity

### DIFF
--- a/lib/dolly/document.rb
+++ b/lib/dolly/document.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'dolly/mango'
 require 'dolly/mango_index'
 require 'dolly/query'
@@ -41,21 +43,25 @@ module Dolly
     attr_writer :doc
 
     def initialize(attributes = {})
+      @doc = doc_for_framework
       properties.each(&build_property(attributes))
     end
 
     protected
 
+    def self.inherited(base)
+      base.instance_variable_set(:@properties, properties.dup)
+    end
+
     def doc
       @doc ||= doc_for_framework
     end
 
-    def self.inherited(base)
-      base.instance_variable_set(:@properties, self.properties.dup)
-    end
-
     def doc_for_framework
+      return @doc if @doc
+
       return {} unless rails?
+
       {}.with_indifferent_access
     end
   end

--- a/lib/dolly/document_creation.rb
+++ b/lib/dolly/document_creation.rb
@@ -13,9 +13,11 @@ module Dolly
 
       new(attributes).tap do |model|
         doc.each_key do |key|
-          next unless model.respond_to?(key.to_sym)
-
-          model.send(:"#{key}=", doc[key])
+          if model.respond_to?(:"#{key}=")
+            model.send(:"#{key}=", doc[key])
+          else
+            model.send(:doc)[key] = doc[key]
+          end
         end
       end
     end

--- a/lib/dolly/document_creation.rb
+++ b/lib/dolly/document_creation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'dolly/properties'
 require 'dolly/framework_helper'
 
@@ -10,7 +12,11 @@ module Dolly
       attributes = property_clean_doc(doc)
 
       new(attributes).tap do |model|
-        model.send(:doc).merge!(doc)
+        doc.each_key do |key|
+          next unless model.respond_to?(key.to_sym)
+
+          model.send(:"#{key}=", doc[key])
+        end
       end
     end
 
@@ -21,7 +27,7 @@ module Dolly
     end
 
     def create(attributes)
-      new(attributes).tap { |model| model.save }
+      new(attributes).tap(&:save)
     end
   end
 end

--- a/lib/dolly/properties.rb
+++ b/lib/dolly/properties.rb
@@ -16,7 +16,10 @@ module Dolly
 
         send(:attr_reader, opt)
 
-        define_method(:"#{opt}=") { |value| write_attribute(opt, value) }
+        define_method(:"#{opt}=") do |value|
+          write_attribute(opt, value)
+        end
+
         define_method(:"#{opt}?") { send(opt) } if prop.boolean?
         define_method(:"[]") { |name| send(name) }
       end

--- a/lib/dolly/property_manager.rb
+++ b/lib/dolly/property_manager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Dolly
   module PropertyManager
     def build_property(attributes)
@@ -7,6 +9,7 @@ module Dolly
       lambda do |property|
         name = property.key
         next unless doc[name].nil?
+
         write_attribute(name, attributes[name])
       end
     end
@@ -14,6 +17,7 @@ module Dolly
     def update_attribute
       lambda do |(key, value)|
         raise InvalidProperty unless valid_property?(key)
+
         write_attribute(key, value)
       end
     end
@@ -21,15 +25,15 @@ module Dolly
     def write_attribute(key, value)
       casted_value = set_property_value(key, value)
       instance_variable_set(:"@#{key}", casted_value)
-      update_doc(key, casted_value)
+      update_doc(key)
     end
 
     def valid_property?(name)
       properties.include?(name)
     end
 
-    def update_doc(key, value)
-      doc[key] = value
+    def update_doc(key, _value = nil)
+      doc.regular_writer(key.to_s, instance_variable_get(:"@#{key}"))
     end
 
     def properties

--- a/lib/dolly/property_manager.rb
+++ b/lib/dolly/property_manager.rb
@@ -16,7 +16,7 @@ module Dolly
 
     def update_attribute
       lambda do |(key, value)|
-        raise InvalidProperty unless valid_property?(key)
+        raise InvalidProperty, "Invalid property: #{key}" unless valid_property?(key)
 
         write_attribute(key, value)
       end
@@ -29,7 +29,7 @@ module Dolly
     end
 
     def valid_property?(name)
-      properties.include?(name)
+      properties.include?(name.to_sym)
     end
 
     def update_doc(key, _value = nil)

--- a/lib/dolly/property_set.rb
+++ b/lib/dolly/property_set.rb
@@ -10,8 +10,11 @@ module Dolly
     end
 
     def [](key)
-      return detect {|property| property.key == key } if key.is_a?(Symbol)
-      super
+      return to_a[key] if key.is_a?(Integer)
+
+      detect do |property|
+        property.key == key.to_sym
+      end
     end
 
     private


### PR DESCRIPTION
Object identity for hash is lost when we switch from `Hash` to `HashWithIndifferentAccess` for role property values.

Current behaivor:

```
class Model < Dolly::Document
  property :foo, class_name: Hash
end

h = {}
doc = Model.new(foo: h)

doc.foo.object_id == doc.send(:doc)[:foo].object_id # => false
```

Expects:

```
doc.foo.object_id == doc.send(:doc)[:foo].object_id # => true
```