### PR TITLE
prepare params for post request

### DIFF
--- a/lib/dolly/connection.rb
+++ b/lib/dolly/connection.rb
@@ -33,7 +33,9 @@ module Dolly
     end
 
     def post resource, data
-      request :post, resource.cgi_escape, data
+      query_str = to_query(data.delete(:query)) if data[:query]
+      query = "?#{query_str}" if query_str
+      request :post, "#{resource.cgi_escape}#{query}", data
     end
 
     def put resource, data


### PR DESCRIPTION
Fixes failing post request with bulk docs, as query params are not correctly being parsed
