### PR TITLE
skip migrations upon request

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
         ruby-version: ['3.1', '3.0', '2.7']
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies
+      - name: Install system dependencies
         run: |
           sudo apt-get install libcurl4-openssl-dev
       - name: Set up Ruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,12 +20,15 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        ruby-version: ['3.1', '3.0', '2.7']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
         with:
-          ruby-version: [ '3.1', '3.0', '2.7' ]
+          ruby-version: ${{ matrix.ruby-version }}
       - name: Install dependencies
         run: bundle install
       - name: Run tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,6 +25,9 @@ jobs:
         ruby-version: ['3.1', '3.0', '2.7']
     steps:
       - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get install libcurl4-openssl-dev
       - name: Set up Ruby
         uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
         with:
-          ruby-version: '3.1', '3.0', '2.7']
+          ruby-version: [ '3.1', '3.0', '2.7' ]
       - name: Install dependencies
         run: bundle install
       - name: Run tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,32 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Ruby
+
+on:
+  push:
+    branches: [ 3.** ]
+  pull_request:
+    branches: [ 3.** ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        with:
+          ruby-version: '3.1', '3.0', '2.7']
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dolly (3.1.3)
+    dolly (3.1.4)
       curb (= 0.9.8)
       oj
 
@@ -17,7 +17,7 @@ GEM
     metaclass (0.0.4)
     mocha (1.9.0)
       metaclass (~> 0.0.1)
-    oj (3.13.21)
+    oj (3.14.3)
     power_assert (1.1.4)
     public_suffix (4.0.6)
     rake (13.0.3)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Dolly3
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/dolly3`. To experiment with that code, run `bin/console` for an interactive prompt.
+The thing you move your couch with...
 
-TODO: Delete this and the text above, and describe your gem
+![example workflow](https://github.com/amco/dolly/actions/workflows/ruby.yml/badge.svg)
 
 ## Installation
 

--- a/config/couchdb.yml
+++ b/config/couchdb.yml
@@ -19,6 +19,10 @@ development:
   partitioned:
     <<: *couchdb
     name: partitioned
+  design_skipped:
+    <<: *couchdb
+    name: design_skipped
+    skip_migrations: true
 
 test:
   default:

--- a/lib/dolly/configuration.rb
+++ b/lib/dolly/configuration.rb
@@ -33,7 +33,7 @@ module Dolly
     def configuration
       @config_data ||= File.read(config_file)
       raise Dolly::InvalidConfigFileError if @config_data&.empty?
-      YAML::load(ERB.new(@config_data).result)[app_env.to_s]
+      YAML::safe_load(ERB.new(@config_data).result, aliases: true)[app_env.to_s]
     end
 
     def config_file

--- a/lib/dolly/connection.rb
+++ b/lib/dolly/connection.rb
@@ -27,6 +27,10 @@ module Dolly
       @app_env = defined?(Rails) ? Rails.env : app_env
     end
 
+    def skip_migrations?
+      env['skip_migrations']
+    end
+
     def get(resource, data = {})
       query = { query: values_to_json(data) } if data
       request :get, resource, query

--- a/lib/dolly/mango_index.rb
+++ b/lib/dolly/mango_index.rb
@@ -25,6 +25,7 @@ module Dolly
       def create_in_database(database, name, fields, type = 'json')
         db_conn = connection_for_database(database)
         return "Migrations for #{database} skiped." if db_conn.skip_migrations?
+
         db_conn.post(DESIGN, build_index_structure(name, fields, type))
       end
 

--- a/lib/dolly/mango_index.rb
+++ b/lib/dolly/mango_index.rb
@@ -49,7 +49,8 @@ module Dolly
       private
 
       def connection_for_database(database)
-        Dolly::Connection.new(database.to_sym, Rails.env || :development)
+        rails_env = defined?(Rails) ? Rails.env : :development
+        Dolly::Connection.new(database.to_sym, rails_env)
       end
 
       def connection

--- a/lib/dolly/mango_index.rb
+++ b/lib/dolly/mango_index.rb
@@ -23,7 +23,9 @@ module Dolly
       end
 
       def create_in_database(database, name, fields, type = 'json')
-        connection_for_database(database).post(DESIGN, build_index_structure(name, fields, type))
+        db_conn = connection_for_database(database)
+        return "Migrations for #{database} skiped." if db_conn.skip_migrations?
+        db_conn.post(DESIGN, build_index_structure(name, fields, type))
       end
 
       def find_by_fields(fields)

--- a/lib/dolly/property_manager.rb
+++ b/lib/dolly/property_manager.rb
@@ -33,7 +33,7 @@ module Dolly
     end
 
     def update_doc(key, _value = nil)
-      doc.regular_writer(key.to_s, instance_variable_get(:"@#{key}"))
+      doc[key.to_s] = instance_variable_get(:"@#{key}")
     end
 
     def properties

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -463,7 +463,7 @@ class DocumentTest < Test::Unit::TestCase
     test_foo = FooBar.new
     test_foo.foo = 'test_value'
     assert_equal 'test_value', test_foo.foo
-    assert_equal 'test_value', test_foo.send(:doc)[:foo]
+    assert_equal 'test_value', test_foo.send(:doc)['foo']
     assert_equal 'test_value', test_foo.instance_variable_get(:@foo)
   end
 

--- a/test/mango_index_test.rb
+++ b/test/mango_index_test.rb
@@ -21,7 +21,7 @@ class MangoIndexTest < Test::Unit::TestCase
         ddoc: nil,
         name:"_all_docs",
         type:"special",
-        def:{ fields:[{ _id:"asc" }] }
+        def:{ fields:[{ _id: "asc" }] }
       },
       {
         ddoc: "_design/1",
@@ -30,6 +30,25 @@ class MangoIndexTest < Test::Unit::TestCase
         def:{ fields:[{ foo:"asc" }] }
       }
     ]}.to_json)
+  end
+
+  test '#create_in_database' do
+    assert_equal "Migrations for design_skipped skiped.", Dolly::MangoIndex.create_in_database(
+      :design_skipped,
+      "demo",
+      [:_id]
+    )
+  end
+
+  test '#create_in_database' do
+    stub_request(:post, "http://localhost:5984/test/_index").
+      to_return(status: 200, body: "Design doc run", headers: {})
+
+    assert_equal "Design doc run", Dolly::MangoIndex.create_in_database(
+      :default,
+      "demo",
+      [:_id]
+    )
   end
 
   test '#delete_all' do


### PR DESCRIPTION
Adding property skip_migrations to db setup so we can skip them when the same db is used in different regions