### PR TITLE
Handle socket leaking and unhandled stale connections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
       ostruct (>= 0.2)
     ostruct (0.6.1)
     power_assert (2.0.5)
-    public_suffix (6.0.1)
+    public_suffix (5.1.1)
     rake (13.2.1)
     rexml (3.4.1)
     rr (3.1.1)
@@ -51,6 +51,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  arm64-darwin-22
   ruby
 
 DEPENDENCIES
@@ -63,4 +64,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.6
+   2.3.22

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Dolly3
+# Dolly
 
-The thing you move your couch with...
+CouchDB adapter for Ruby. The thing you move your couch with...
 
 ![example workflow](https://github.com/amco/dolly/actions/workflows/ruby.yml/badge.svg)
 
@@ -9,7 +9,7 @@ The thing you move your couch with...
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'dolly3'
+gem 'dolly'
 ```
 
 And then execute:
@@ -18,61 +18,112 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install dolly3
+    $ gem install dolly
+
+Configure CouchDB in `config/couchdb.yml` (see the [sample config](config/couchdb.yml) in this repo).
 
 ## Usage
 
-TODO: Write usage instructions here
+Define documents as usual:
+
+```ruby
+class FooBar < Dolly::Document
+  property :foo, :bar
+  timestamps!
+end
+
+doc = FooBar.create(foo: 'a', bar: 'b')
+FooBar.find(doc.id)
+```
+
+The public `Dolly::Connection` API (`get`, `post`, `put`, `delete`, `request`, `view`, `attach`, `uuids`, etc.) is unchanged for application code.
+
+### Connection reuse (Curb)
+
+Dolly uses [Curb](https://github.com/taf2/curb) under the hood. Newer Curb releases keep HTTP connections alive, which previously leaked one TCP socket per Dolly request and could exhaust CouchDB's accept backlog during bursts (Sidekiq jobs, seeds, Passenger workers).
+
+Dolly now reuses **one `Curl::Easy` handle per thread** via internal `Dolly::Curl`
+collaborators (`Connection` for transport/retries, `WriteReconciler` for ambiguous writes):
+
+- Persistent keep-alive to CouchDB without opening a new socket on every call
+- Safe for typical **Passenger** (one request per thread/process) and **Sidekiq** (one job per thread) deployments
+- Not safe under fiber-based servers that interleave multiple Dolly requests on a single thread
+
+### Stale keep-alive handling
+
+If CouchDB closes an idle keep-alive socket, Curb may raise a transport error (`GotNothingError`, `RecvError`, `SendError`, `PartialFileError`). Dolly always discards the dead handle, then:
+
+| Request | Behavior |
+|---------|----------|
+| `GET`, `HEAD` | Retry once on a fresh connection |
+| Read-only `POST` (`/_find`, `/_all_docs`) | Retry once on a fresh connection |
+| Document `PUT` | Reconcile by reading the document; succeed if content matches, retry once if the write clearly did not land, otherwise raise |
+| Document `DELETE` (with `rev`) | Reconcile by reading the document; succeed if gone/deleted, retry once if the same rev is still present, otherwise raise |
+| `POST /_bulk_docs` | Reconcile via `/_all_docs`; retry only documents that clearly did not apply |
+| Attachments and other writes | Do **not** blind-retry; raise |
+
+### `Dolly::AmbiguousWriteError`
+
+Raised when a write may or may not have been applied (transport failed after the request was possibly processed, and reconciliation cannot prove the outcome).
+
+```ruby
+begin
+  doc.save!
+rescue Dolly::AmbiguousWriteError => e
+  e.method # => :put
+  e.uri    # => #<URI::HTTP ...>
+  e.cause  # => original Curl::Err::*
+end
+```
+
+Handle this in jobs/seeds by reloading or re-checking the document before retrying the business operation.
 
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
+```bash
+bundle exec rake test
+```
+
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/dolly3.
+Bug reports and pull requests are welcome on GitHub at https://github.com/amco/dolly.
 
-
-## Migrating from couch 1.x to 2.x
+## Migrating from CouchDB 1.x to 2.x
 
 [Official docs](https://docs.couchdb.org/en/2.3.1/install/index.html)
 
+You will need to uninstall the couchdb service with brew:
 
-You will need to uninstall the couchdb service with brew
-
-`brew services stop couchdb`
-`brew services uninstall couchdb`
-
-Download the application from the following source
-
-http://couchdb.apache.org/#download
-
-launch fauxton and check your installation
-
-Copy [this file](https://github.com/apache/couchdb/blob/master/rel/overlay/bin/couchup) into your filesystem
-
-
-make it executable
-
-`chmod +x couchup.py`
-
-and run it
-
-`./couchup.py -h`
-
-You might need to install python 3 and pip3 and the following libs
-
-`pip3 install requests progressbar2`
-
-move your .couch files into the specified `database_dir` in your [fauxton config](http://127.0.0.1:5984/_utils/#_config/couchdb@localhost)
-
-
+```bash
+brew services stop couchdb
+brew services uninstall couchdb
 ```
-$ ./couchup list           # Shows your unmigrated 1.x databases
-$ ./couchup replicate -a   # Replicates your 1.x DBs to 2.x
-$ ./couchup rebuild -a     # Optional; starts rebuilding your views
-$ ./couchup delete -a      # Deletes your 1.x DBs (careful!)
-$ ./couchup list           # Should show no remaining databases!
+
+Download the application from http://couchdb.apache.org/#download, launch Fauxton, and check your installation.
+
+Copy [this file](https://github.com/apache/couchdb/blob/master/rel/overlay/bin/couchup) into your filesystem, make it executable, and run it:
+
+```bash
+chmod +x couchup.py
+./couchup.py -h
+```
+
+You might need Python 3, pip3, and:
+
+```bash
+pip3 install requests progressbar2
+```
+
+Move your `.couch` files into the specified `database_dir` in your [Fauxton config](http://127.0.0.1:5984/_utils/#_config/couchdb@localhost), then:
+
+```bash
+./couchup list           # Shows your unmigrated 1.x databases
+./couchup replicate -a   # Replicates your 1.x DBs to 2.x
+./couchup rebuild -a     # Optional; starts rebuilding your views
+./couchup delete -a      # Deletes your 1.x DBs (careful!)
+./couchup list           # Should show no remaining databases!
 ```

--- a/dolly.gemspec
+++ b/dolly.gemspec
@@ -9,8 +9,9 @@ Gem::Specification.new do |spec|
   spec.authors       = ["javierg"]
   spec.email         = ["javierg@amcoonline.net"]
 
-  spec.description   = "couch adapter "
-  spec.summary       = "will write something"
+  spec.description   = "CouchDB adapter for Ruby with thread-local Curb connections, " \
+                       "stale keep-alive recovery, and safe write reconciliation."
+  spec.summary       = "CouchDB adapter for Ruby"
   spec.homepage      = "https://www.amco.me"
 
   spec.files         = Dir["README.md", "lib/**/*"]

--- a/lib/dolly/connection.rb
+++ b/lib/dolly/connection.rb
@@ -1,19 +1,17 @@
 # frozen_string_literal: true
 
-require 'curb'
-require 'oj'
 require 'cgi'
 require 'net/http'
 require 'dolly/request_header'
 require 'dolly/exceptions'
 require 'dolly/configuration'
+require 'dolly/curl'
 require 'refinements/string_refinements'
-require 'dolly/framework_helper'
 
 module Dolly
   class Connection
     include Dolly::Configuration
-    include Dolly::FrameworkHelper
+    include Dolly::Curl::ResponseFormatter
     attr_reader :db, :app_env
 
     DEFAULT_HEADER = { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
@@ -78,7 +76,7 @@ module Dolly
       body        = fetch_body(data)
       uri         = URI("#{base_uri}#{db_resource}")
 
-      conn = curl_method_call(method, uri, body) do |curl|
+      conn = curl_connection.request(method, uri, body) do |curl|
         if env['username'] && !env['username'].empty?
           curl.http_auth_types = :basic
           curl.username = env['username']
@@ -88,10 +86,19 @@ module Dolly
         headers.each { |k, v| curl.headers[k] = v } unless !headers || headers.empty?
       end
 
+      return conn unless conn.is_a?(::Curl::Easy)
+
       response_format(conn, method)
     end
 
     private
+
+    def curl_connection
+      @curl_connection ||= Dolly::Curl::Connection.new(
+        db_name: db_name,
+        reader: Dolly::Curl::Reader.new(self)
+      )
+    end
 
     def fetch_headers(data)
       return unless data.is_a?(Hash)
@@ -103,28 +110,6 @@ module Dolly
 
       data&.delete(:headers)
       data&.merge!(data&.delete(:query) || {})
-    end
-
-    def curl_method_call(method, uri, data, &block)
-      return Curl::Easy.http_head(uri.to_s, &block) if method.to_sym == :head
-      return Curl.delete(uri.to_s, &block) if method.to_sym == :delete
-      return Curl.send(method, uri, data, &block) if method.to_sym == :get
-      Curl.send(method, uri.to_s, data.to_json, &block)
-    end
-
-    def response_format(res, method)
-      raise Dolly::ResourceNotFound if res.status.to_i == 404
-      raise Dolly::ServerError.new(res.status.to_i) if (400..600).include? res.status.to_i
-      return res.header_str if method == :head
-
-      data = Oj.load(res.body_str, symbol_keys: true)
-      return data unless rails?
-      return data.with_indifferent_access if data.is_a?(Hash)
-      data
-    rescue Oj::ParseError
-      res.body_str
-    ensure
-      GC.start if res&.body_str&.length&.to_i > 250000
     end
 
     def values_to_json hash

--- a/lib/dolly/curl.rb
+++ b/lib/dolly/curl.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'dolly/curl/stale_connection'
+require 'dolly/curl/response_formatter'
+require 'dolly/curl/document_helper'
+require 'dolly/curl/reader'
+require 'dolly/curl/write_reconciler'
+require 'dolly/curl/connection'
+
+module Dolly
+  # Namespace for Curb-based HTTP transport collaborators.
+  #
+  # Public CouchDB client API remains Dolly::Connection. Classes under
+  # Dolly::Curl are internal transport/retry helpers.
+  module Curl
+  end
+end

--- a/lib/dolly/curl/connection.rb
+++ b/lib/dolly/curl/connection.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'curb'
+require 'cgi'
+require 'dolly/curl/stale_connection'
+require 'dolly/curl/write_reconciler'
+
+module Dolly
+  module Curl
+    # Thread-local Curb transport with stale-connection handling.
+    #
+    # Reuses one ::Curl::Easy handle per thread, retries safe reads once, and
+    # delegates ambiguous writes to WriteReconciler.
+    #
+    # Assumes one in-flight request per thread (not safe under fiber-based servers).
+    #
+    # +reader+ must respond to:
+    # - fetch_document(doc_id) -> Hash or nil
+    # - fetch_documents_by_ids(ids) -> Hash keyed by id
+    class Connection
+      MAX_STALE_RETRIES = 1
+      THREAD_STORE_KEY = :dolly_curl_easy
+      READ_ONLY_POST_SUFFIXES = %w[/_find /_all_docs].freeze
+
+      attr_reader :db_name, :reader
+
+      def initialize(db_name:, reader:, reconciler: nil)
+        @db_name = db_name
+        @reader = reader
+        @reconciler = reconciler
+      end
+
+      def request(method, uri, data = nil, retries = 0, &block)
+        perform(method, uri, data, &block)
+      rescue *StaleConnection::ERRORS => error
+        discard_handle
+
+        if safe_to_retry?(method, uri)
+          raise error if retries >= MAX_STALE_RETRIES
+
+          return request(method, uri, data, retries + 1, &block)
+        end
+
+        reconciler.reconcile(method, uri, data, error, &block)
+      end
+
+      def perform(method, uri, data = nil, &block)
+        handle = prepare_handle(uri, &block)
+        dispatch_http(handle, method, data)
+        handle
+      end
+
+      def discard_handle
+        store = Thread.current[THREAD_STORE_KEY]
+        return unless store
+
+        handle = store.delete(self.class)
+        handle&.close
+      rescue StandardError
+        nil
+      end
+
+      def thread_local_handle
+        store = Thread.current[THREAD_STORE_KEY] ||= {}
+        store[self.class] ||= ::Curl::Easy.new
+      end
+
+      private
+
+      def reconciler
+        @reconciler ||= WriteReconciler.new(
+          transport: self,
+          reader: reader,
+          db_name: db_name
+        )
+      end
+
+      def prepare_handle(uri)
+        handle = thread_local_handle
+        handle.reset
+        handle.url = uri.to_s
+        handle.headers['Content-Type'] = 'application/json'
+        handle.headers['Accept'] = 'application/json'
+        yield handle if block_given?
+        handle
+      end
+
+      def dispatch_http(handle, method, data)
+        case method.to_sym
+        when :head then handle.http_head
+        when :delete then handle.http_delete
+        when :get then http_get(handle, data)
+        when :post then handle.http_post(payload_json(data))
+        when :put then handle.http_put(payload_json(data))
+        else
+          raise ArgumentError, "unsupported HTTP method: #{method}"
+        end
+      end
+
+      def http_get(handle, data)
+        apply_get_query!(handle, data)
+        handle.http_get
+      end
+
+      def payload_json(data)
+        return data if data.is_a?(String)
+
+        data.to_json
+      end
+
+      def apply_get_query!(handle, data)
+        return if data.nil? || data.empty?
+
+        query = data.map do |key, value|
+          "#{CGI.escape(key.to_s)}=#{CGI.escape(value.to_s)}"
+        end.join('&')
+        separator = handle.url.include?('?') ? '&' : '?'
+        handle.url = "#{handle.url}#{separator}#{query}"
+      end
+
+      def safe_to_retry?(method, uri)
+        case method.to_sym
+        when :get, :head
+          true
+        when :post
+          read_only_post?(uri)
+        else
+          false
+        end
+      end
+
+      def read_only_post?(uri)
+        READ_ONLY_POST_SUFFIXES.any? { |suffix| uri.path.end_with?(suffix) }
+      end
+    end
+  end
+end

--- a/lib/dolly/curl/connection.rb
+++ b/lib/dolly/curl/connection.rb
@@ -62,10 +62,23 @@ module Dolly
 
       def thread_local_handle
         store = Thread.current[THREAD_STORE_KEY] ||= {}
-        store[self.class] ||= ::Curl::Easy.new
+        handle = store[self.class]
+        return handle unless handle.nil? || mocked_curl_class?(handle)
+
+        begin
+          handle&.close
+        rescue StandardError
+          nil
+        end
+
+        store[self.class] = ::Curl::Easy.new
       end
 
       private
+
+      def mocked_curl_class?(handle)
+        !handle.instance_of?(::Curl::Easy)
+      end
 
       def reconciler
         @reconciler ||= WriteReconciler.new(

--- a/lib/dolly/curl/document_helper.rb
+++ b/lib/dolly/curl/document_helper.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'cgi'
+require 'oj'
+
+module Dolly
+  module Curl
+    # Document identity, URI parsing, and equality helpers for write reconciliation.
+    class DocumentHelper
+      IGNORED_COMPARE_KEYS = %i[_rev].freeze
+
+      def initialize(db_name:)
+        @db_name = db_name
+      end
+
+      def id_from_uri(uri)
+        prefix = "/#{@db_name}/"
+        path = uri.path
+        return nil unless path.start_with?(prefix)
+
+        rest = path[prefix.length..-1]
+        return nil if rest.nil? || rest.empty?
+        return nil if rest.start_with?('_')
+        return nil if rest.include?('/')
+
+        CGI.unescape(rest)
+      end
+
+      def rev_from_uri(uri)
+        return nil unless uri.query
+
+        CGI.parse(uri.query)['rev']&.first
+      end
+
+      def normalize(data)
+        return data.transform_keys(&:to_sym) if data.is_a?(Hash)
+        return nil if data.nil?
+
+        parsed = data.is_a?(String) ? Oj.load(data, symbol_keys: true) : nil
+        parsed.is_a?(Hash) ? parsed : nil
+      rescue Oj::ParseError
+        nil
+      end
+
+      def matches?(stored, intended)
+        intended.each do |key, expected|
+          key = key.to_sym
+          next if IGNORED_COMPARE_KEYS.include?(key)
+          return false unless value(stored, key) == expected
+        end
+        true
+      end
+
+      def value(doc, key)
+        return doc[key] if doc.key?(key)
+        return doc[key.to_s] if doc.key?(key.to_s)
+
+        nil
+      end
+
+      def id(doc)
+        value(doc, :_id)
+      end
+
+      def revision(doc)
+        value(doc, :_rev)
+      end
+
+      def deleted?(doc)
+        value(doc, :_deleted)
+      end
+
+      def docs_from_bulk_payload(data)
+        payload = normalize(data)
+        return [] unless payload
+
+        Array(payload[:docs]).map { |doc| normalize(doc) }.compact
+      end
+    end
+  end
+end

--- a/lib/dolly/curl/reader.rb
+++ b/lib/dolly/curl/reader.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'cgi'
+require 'dolly/exceptions'
+
+module Dolly
+  module Curl
+    # Reads CouchDB state for write reconciliation via Connection's public API.
+    class Reader
+      def initialize(connection)
+        @connection = connection
+      end
+
+      def fetch_document(doc_id)
+        @connection.request(:get, CGI.escape(doc_id.to_s))
+      rescue Dolly::ResourceNotFound
+        nil
+      end
+
+      def fetch_documents_by_ids(ids)
+        response = @connection.post('_all_docs', keys: ids, query: { include_docs: true })
+        rows = response[:rows] || []
+        rows.each_with_object({}) do |row, memo|
+          memo[row[:id] || row[:key]] = row
+        end
+      end
+    end
+  end
+end

--- a/lib/dolly/curl/response_formatter.rb
+++ b/lib/dolly/curl/response_formatter.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'oj'
+require 'dolly/framework_helper'
+require 'dolly/exceptions'
+
+module Dolly
+  module Curl
+    module ResponseFormatter
+      include Dolly::FrameworkHelper
+
+      private
+
+      def response_format(res, method)
+        status = res.status.to_i
+        raise Dolly::ResourceNotFound if status == 404
+        raise Dolly::ServerError.new(status) if (400..600).include?(status)
+        return res.header_str if method == :head
+
+        data = Oj.load(res.body_str, symbol_keys: true)
+        return data unless rails?
+        return data.with_indifferent_access if data.is_a?(Hash)
+
+        data
+      rescue Oj::ParseError
+        res.body_str
+      end
+    end
+  end
+end

--- a/lib/dolly/curl/stale_connection.rb
+++ b/lib/dolly/curl/stale_connection.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'curb'
+
+module Dolly
+  module Curl
+    module StaleConnection
+      ERRORS = [
+        ::Curl::Err::GotNothingError,
+        ::Curl::Err::RecvError,
+        ::Curl::Err::SendError,
+        ::Curl::Err::PartialFileError
+      ].freeze
+    end
+  end
+end

--- a/lib/dolly/curl/write_reconciler.rb
+++ b/lib/dolly/curl/write_reconciler.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require 'dolly/curl/document_helper'
+require 'dolly/exceptions'
+require 'dolly/curl/response_formatter'
+require 'dolly/curl/stale_connection'
+
+module Dolly
+  module Curl
+    # Reconciles ambiguous CouchDB writes after stale keep-alive failures.
+    # Depends on a transport that responds to +perform+ and +discard_handle+.
+    class WriteReconciler
+      include ResponseFormatter
+
+      def initialize(transport:, reader:, db_name:)
+        @transport = transport
+        @reader = reader
+        @documents = DocumentHelper.new(db_name: db_name)
+      end
+
+      def reconcile(method, uri, data, error, &block)
+        case method.to_sym
+        when :put then reconcile_put(uri, data, error, &block)
+        when :delete then reconcile_delete(uri, data, error, &block)
+        when :post then reconcile_post(uri, data, error, &block)
+        else raise_ambiguous(method, uri, error)
+        end
+      end
+
+      private
+
+      attr_reader :transport, :reader, :documents
+
+      def reconcile_post(uri, data, error, &block)
+        return reconcile_bulk_docs(uri, data, error, &block) if bulk_docs?(uri)
+
+        raise_ambiguous(:post, uri, error)
+      end
+
+      def reconcile_put(uri, data, error, &block)
+        doc_id, intended = put_target(uri, data, error)
+        resolve_put(uri, data, doc_id, intended, error, &block)
+      rescue *StaleConnection::ERRORS => retry_error
+        transport.discard_handle
+        raise_ambiguous(:put, uri, retry_error)
+      end
+
+      def put_target(uri, data, error)
+        doc_id = documents.id_from_uri(uri)
+        raise_ambiguous(:put, uri, error) unless doc_id
+
+        intended = documents.normalize(data)
+        raise_ambiguous(:put, uri, error) unless intended
+
+        [doc_id, intended]
+      end
+
+      def resolve_put(uri, data, doc_id, intended, error, &block)
+        stored = reader.fetch_document(doc_id)
+        return put_success(stored) if put_already_applied?(stored, intended)
+        return transport.perform(:put, uri, data, &block) if put_retryable?(stored, intended)
+
+        raise_ambiguous(:put, uri, error)
+      end
+
+      def put_already_applied?(stored, intended)
+        stored && documents.matches?(stored, intended)
+      end
+
+      def put_retryable?(stored, intended)
+        return documents.revision(intended).nil? if stored.nil?
+
+        revision = documents.revision(intended)
+        revision && documents.value(stored, :_rev) == revision
+      end
+
+      def put_success(stored)
+        {
+          ok: true,
+          id: documents.value(stored, :_id),
+          rev: documents.value(stored, :_rev)
+        }
+      end
+
+      def reconcile_delete(uri, data, error, &block)
+        doc_id = documents.id_from_uri(uri)
+        raise_ambiguous(:delete, uri, error) unless doc_id
+
+        expected_rev = documents.rev_from_uri(uri)
+        raise_ambiguous(:delete, uri, error) unless expected_rev
+
+        resolve_delete(uri, data, doc_id, expected_rev, error, &block)
+      rescue *StaleConnection::ERRORS => retry_error
+        transport.discard_handle
+        raise_ambiguous(:delete, uri, retry_error)
+      end
+
+      def resolve_delete(uri, data, doc_id, expected_rev, error, &block)
+        stored = reader.fetch_document(doc_id)
+        return { ok: true, id: doc_id } if stored.nil?
+        return { ok: true, id: doc_id } if documents.deleted?(stored)
+        return transport.perform(:delete, uri, data, &block) if documents.value(stored, :_rev) == expected_rev
+
+        raise_ambiguous(:delete, uri, error)
+      end
+
+      def reconcile_bulk_docs(uri, data, error, &block)
+        docs = documents.docs_from_bulk_payload(data)
+        raise_ambiguous(:post, uri, error) if docs.empty?
+
+        ids = docs.map { |doc| documents.id(doc) }.compact
+        raise_ambiguous(:post, uri, error) if ids.empty? || ids.size != docs.size
+
+        classify_and_retry_bulk(uri, docs, ids, error, &block)
+      rescue *StaleConnection::ERRORS => retry_error
+        transport.discard_handle
+        raise_ambiguous(:post, uri, retry_error)
+      end
+
+      def classify_and_retry_bulk(uri, docs, ids, error, &block)
+        rows_by_id = reader.fetch_documents_by_ids(ids)
+        results = []
+        pending = []
+
+        docs.each do |doc|
+          row = rows_by_id[documents.id(doc)]
+          stored = row && row[:doc]
+
+          if bulk_committed?(doc, stored, row)
+            results << bulk_success(doc, stored)
+          elsif bulk_unapplied?(doc, stored)
+            pending << doc
+          else
+            raise_ambiguous(:post, uri, error)
+          end
+        end
+
+        results.concat(retry_pending_bulk(uri, pending, &block)) if pending.any?
+        results
+      end
+
+      def retry_pending_bulk(uri, pending, &block)
+        retry_response = transport.perform(:post, uri, { docs: pending }, &block)
+        retry_results = response_format(retry_response, :post)
+        retry_results = [retry_results] unless retry_results.is_a?(Array)
+        retry_results
+      end
+
+      def bulk_committed?(intended, stored, row)
+        return true if documents.deleted?(intended) && bulk_deleted?(stored, row)
+        return false if stored.nil?
+
+        documents.matches?(stored, intended)
+      end
+
+      def bulk_deleted?(stored, row)
+        stored.nil? || documents.deleted?(stored) || row&.dig(:value, :deleted)
+      end
+
+      def bulk_unapplied?(intended, stored)
+        return true if stored.nil? && !documents.deleted?(intended)
+        return true if delete_still_present?(intended, stored)
+        return true if update_still_at_source_rev?(intended, stored)
+
+        false
+      end
+
+      def delete_still_present?(intended, stored)
+        documents.deleted?(intended) &&
+          stored &&
+          !documents.deleted?(stored) &&
+          documents.value(stored, :_rev) == documents.revision(intended)
+      end
+
+      def update_still_at_source_rev?(intended, stored)
+        !documents.deleted?(intended) &&
+          stored &&
+          documents.revision(intended) &&
+          documents.value(stored, :_rev) == documents.revision(intended)
+      end
+
+      def bulk_success(intended, stored)
+        id = documents.id(intended)
+        return deleted_bulk_success(id, stored) if documents.deleted?(intended)
+
+        { ok: true, id: id, rev: documents.value(stored, :_rev) }
+      end
+
+      def deleted_bulk_success(id, stored)
+        result = { ok: true, id: id }
+        rev = stored && documents.value(stored, :_rev)
+        result[:rev] = rev if rev
+        result
+      end
+
+      def bulk_docs?(uri)
+        uri.path.end_with?('/_bulk_docs')
+      end
+
+      def raise_ambiguous(method, uri, error)
+        raise Dolly::AmbiguousWriteError.new(method: method, uri: uri, cause: error)
+      end
+    end
+  end
+end

--- a/lib/dolly/document.rb
+++ b/lib/dolly/document.rb
@@ -58,7 +58,7 @@ module Dolly
     end
 
     def doc_for_framework
-      return @doc if @doc
+      return @doc if defined?(@doc) && @doc
 
       return {} unless rails?
 

--- a/lib/dolly/exceptions.rb
+++ b/lib/dolly/exceptions.rb
@@ -47,6 +47,22 @@ module Dolly
     end
   end
 
+  class AmbiguousWriteError < RuntimeError
+    attr_reader :method, :uri, :cause
+
+    def initialize(method:, uri:, cause:)
+      @method = method
+      @uri = uri
+      @cause = cause
+      super()
+    end
+
+    def to_s
+      "Ambiguous #{method.upcase} to #{uri} after #{cause.class}: #{cause.message}. " \
+        'The request may or may not have been applied.'
+    end
+  end
+
   class PartitionedDataBaseExpectedError < RuntimeError; end
   class IndexNotFoundError < RuntimeError; end
   class InvalidConfigFileError < RuntimeError; end

--- a/test/bulk_document_test.rb
+++ b/test/bulk_document_test.rb
@@ -44,4 +44,71 @@ class BulkDocumentTest < Test::Unit::TestCase
     assert_equal [], @doc.docs
     assert_equal [], @doc.payload[:docs]
   end
+
+  test 'save reconciles when bulk post is ambiguous but docs are committed' do
+    docs = 2.times.map { |i| Doc.new(name: "doc-#{i}").tap { |d| d.id = "doc/#{i}" } }
+    docs.each { |d| @doc << d }
+
+    connection = @doc.connection
+    curl = connection.send(:curl_connection)
+    curl.stubs(:perform).with do |method, uri, *_|
+      method.to_sym == :post && uri.path.end_with?('/_bulk_docs')
+    end.raises(Curl::Err::RecvError)
+
+    curl.reader.stubs(:fetch_documents_by_ids).returns(
+      docs.each_with_object({}) do |d, memo|
+        memo[d.id] = { id: d.id, doc: d.to_h.merge(_rev: "1-#{d.id}") }
+      end
+    )
+
+    @doc.save
+
+    assert_equal [], @doc.errors
+    assert_equal [], @doc.docs
+    docs.each { |d| assert_equal "1-#{d.id}", d.rev }
+  end
+
+  test 'save retries only unapplied docs after ambiguous bulk post' do
+    committed = Doc.new(name: 'committed').tap { |d| d.id = 'doc/1' }
+    pending = Doc.new(name: 'pending').tap { |d| d.id = 'doc/2' }
+    @doc << committed
+    @doc << pending
+
+    connection = @doc.connection
+    curl = connection.send(:curl_connection)
+    bulk_attempts = 0
+    retry_body = [{ ok: true, id: 'doc/2', rev: '2-doc/2' }]
+    pending_payloads = []
+
+    curl.stubs(:perform).with do |method, uri, data, *_|
+      next false unless method.to_sym == :post && uri.path.end_with?('/_bulk_docs')
+
+      bulk_attempts += 1
+      raise Curl::Err::RecvError if bulk_attempts == 1
+
+      pending_payloads << data
+      true
+    end.returns(
+      stub(
+        status: '200',
+        body_str: retry_body.to_json,
+        header_str: ''
+      )
+    )
+
+    curl.reader.stubs(:fetch_documents_by_ids).returns(
+      'doc/1' => { id: 'doc/1', doc: committed.to_h.merge(_rev: '1-doc/1') },
+      'doc/2' => { id: 'doc/2', error: 'not_found' }
+    )
+
+    @doc.save
+
+    assert_equal 2, bulk_attempts
+    assert_equal 1, pending_payloads.size
+    assert_equal ['doc/2'], pending_payloads.first[:docs].map { |d| d[:_id] || d['_id'] }
+    assert_equal [], @doc.errors
+    assert_equal [], @doc.docs
+    assert_equal '1-doc/1', committed.rev
+    assert_equal '2-doc/2', pending.rev
+  end
 end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ConnectionTest < Test::Unit::TestCase
+  setup do
+    clear_thread_local_curl!
+    @connection = Dolly::Connection.new
+  end
+
+  teardown do
+    clear_thread_local_curl!
+  end
+
+  test 'response_format raises ResourceNotFound for 404 responses' do
+    response = build_curl_response(status: 404, body: '{"error":"not_found"}')
+
+    assert_raises(Dolly::ResourceNotFound) do
+      @connection.send(:response_format, response, :get)
+    end
+  end
+
+  test 'response_format raises ServerError for 5xx responses' do
+    response = build_curl_response(status: 500, body: '{"error":"internal"}')
+
+    error = assert_raises(Dolly::ServerError) do
+      @connection.send(:response_format, response, :get)
+    end
+
+    assert_equal 500, error.instance_variable_get(:@msg)
+  end
+
+  test 'response_format raises ServerError for 4xx responses' do
+    response = build_curl_response(status: 400, body: '{"error":"bad_request"}')
+
+    error = assert_raises(Dolly::ServerError) do
+      @connection.send(:response_format, response, :get)
+    end
+
+    assert_equal 400, error.instance_variable_get(:@msg)
+  end
+
+  test 'response_format returns headers for head responses' do
+    response = build_curl_response(status: 200, body: '', headers: "ETag: \"abc\"\r\n")
+
+    assert_equal "ETag: \"abc\"\r\n", @connection.send(:response_format, response, :head)
+  end
+
+  test 'response_format returns parsed json for successful responses' do
+    response = build_curl_response(status: 200, body: '{"ok":true,"count":2}')
+
+    assert_equal({ ok: true, count: 2 }, @connection.send(:response_format, response, :get))
+  end
+
+  test 'response_format returns raw body when json parsing fails' do
+    response = build_curl_response(status: 200, body: 'plain text')
+
+    assert_equal 'plain text', @connection.send(:response_format, response, :get)
+  end
+
+  test 'request performs get against couchdb with query params' do
+    stub_request(:get, 'http://localhost:5984/test/doc/1?rev=1-abc')
+      .to_return(status: 200, body: '{"ok":true}', headers: { 'Content-Type' => 'application/json' })
+
+    result = @connection.request(:get, 'doc/1', rev: '1-abc')
+
+    assert_equal({ ok: true }, result)
+  end
+
+  test 'request path reuses thread local curl between calls' do
+    stub_request(:get, %r{http://localhost:5984/test/_uuids})
+      .to_return(status: 200, body: '{"uuids":["abc"]}', headers: { 'Content-Type' => 'application/json' })
+
+    @connection.tools('_uuids')
+    first_handle = @connection.send(:curl_connection).thread_local_handle
+    @connection.tools('_uuids')
+    second_handle = @connection.send(:curl_connection).thread_local_handle
+
+    assert_same first_handle, second_handle
+  end
+
+  test 'request performs post against couchdb' do
+    stub_request(:post, 'http://localhost:5984/test/_bulk_docs')
+      .with(body: '{"docs":[]}')
+      .to_return(status: 200, body: '{"ok":true}', headers: { 'Content-Type' => 'application/json' })
+
+    result = @connection.request(:post, '_bulk_docs', docs: [])
+
+    assert_equal({ ok: true }, result)
+  end
+
+  test 'request performs put against couchdb' do
+    stub_request(:put, 'http://localhost:5984/test/doc%2F1')
+      .with(body: '{"foo":"bar"}')
+      .to_return(status: 201, body: '{"ok":true,"id":"doc/1","rev":"1-abc"}', headers: { 'Content-Type' => 'application/json' })
+
+    result = @connection.put('doc/1', foo: 'bar')
+
+    assert_equal({ ok: true, id: 'doc/1', rev: '1-abc' }, result)
+  end
+
+  test 'request performs delete against couchdb' do
+    stub_request(:delete, 'http://localhost:5984/test/doc%2F1?rev=1-abc')
+      .to_return(status: 200, body: '{"ok":true}', headers: { 'Content-Type' => 'application/json' })
+
+    result = @connection.delete('doc/1', '1-abc')
+
+    assert_equal({ ok: true }, result)
+  end
+
+  test 'request sends custom headers' do
+    stub_request(:put, 'http://localhost:5984/test/doc%2F1/attachment.txt')
+      .with(headers: { 'Content-Type' => 'text/plain' })
+      .to_return(status: 201, body: '{"ok":true}', headers: { 'Content-Type' => 'application/json' })
+
+    result = @connection.attach('doc/1', 'attachment.txt', 'payload', 'Content-Type' => 'text/plain')
+
+    assert_equal({ ok: true }, result)
+  end
+
+  test 'curl transport helpers stay outside the public connection api' do
+    assert_raises(NoMethodError) { @connection.curl_connection }
+    assert_raises(NoMethodError) { @connection.fetch_document('doc/1') }
+    assert_raises(NoMethodError) { @connection.fetch_documents_by_ids(['doc/1']) }
+
+    curl = @connection.send(:curl_connection)
+    assert_equal 'test', curl.db_name
+    assert_instance_of Dolly::Curl::Reader, curl.reader
+  end
+
+  private
+
+  def build_curl_response(status:, body:, headers: '')
+    stub(status: status.to_s, body_str: body, header_str: headers)
+  end
+
+  def clear_thread_local_curl!
+    store = Thread.current[Dolly::Curl::Connection::THREAD_STORE_KEY]
+    return unless store
+
+    store.each_value { |handle| handle.close rescue nil }
+    store.clear
+    Thread.current[Dolly::Curl::Connection::THREAD_STORE_KEY] = nil
+  end
+end

--- a/test/curl/connection_test.rb
+++ b/test/curl/connection_test.rb
@@ -1,0 +1,455 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Dolly::Curl::ConnectionTest < Test::Unit::TestCase
+  setup do
+    clear_thread_local_curl!
+    @reader = Object.new
+    def @reader.fetch_document(*)
+      nil
+    end
+
+    def @reader.fetch_documents_by_ids(*)
+      {}
+    end
+
+    @curl = Dolly::Curl::Connection.new(db_name: 'test', reader: @reader)
+  end
+
+  teardown do
+    clear_thread_local_curl!
+  end
+
+  test 'reuses the same curl handle on a thread' do
+    first = @curl.thread_local_handle
+    second = @curl.thread_local_handle
+
+    assert_same first, second
+  end
+
+  test 'uses separate curl handles per thread' do
+    handles = Queue.new
+
+    threads = 2.times.map do
+      Thread.new do
+        curl = Dolly::Curl::Connection.new(db_name: 'test', reader: stub_everything('reader'))
+        handles << curl.thread_local_handle
+      ensure
+        store = Thread.current[Dolly::Curl::Connection::THREAD_STORE_KEY]
+        next unless store
+
+        store.each_value { |handle| handle.close rescue nil }
+        Thread.current[Dolly::Curl::Connection::THREAD_STORE_KEY] = nil
+      end
+    end
+    threads.each(&:join)
+
+    collected = []
+    collected << handles.pop until handles.empty?
+
+    assert_equal 2, collected.map(&:object_id).uniq.size
+  end
+
+  test 'discard_handle removes and closes the handle' do
+    curl_easy = @curl.thread_local_handle
+    curl_easy.expects(:close).once
+
+    @curl.discard_handle
+
+    store = Thread.current[Dolly::Curl::Connection::THREAD_STORE_KEY]
+    assert_nil store[Dolly::Curl::Connection]
+  end
+
+  test 'retries once after a stale connection error on get' do
+    response = build_curl_response(status: 200, body: '{"ok":true}')
+
+    @curl.stubs(:perform)
+      .raises(Curl::Err::GotNothingError)
+      .then.returns(response)
+    @curl.expects(:discard_handle).once
+
+    result = @curl.request(:get, URI('http://localhost:5984/test/doc'), {})
+
+    assert_equal response, result
+  end
+
+  test 'raises after stale connection retries are exhausted on get' do
+    @curl.stubs(:perform).raises(Curl::Err::RecvError)
+    @curl.expects(:discard_handle).twice
+
+    assert_raises(Curl::Err::RecvError) do
+      @curl.request(:get, URI('http://localhost:5984/test/doc'), {})
+    end
+  end
+
+  test 'retries once after SendError on read-only post' do
+    response = build_curl_response(status: 200, body: '{"docs":[]}')
+
+    @curl.stubs(:perform)
+      .raises(Curl::Err::SendError)
+      .then.returns(response)
+    @curl.expects(:discard_handle).once
+
+    result = @curl.request(
+      :post,
+      URI('http://localhost:5984/test/_find'),
+      { selector: { type: 'doc' } }
+    )
+
+    assert_equal response, result
+  end
+
+  test 'retries once after PartialFileError on _all_docs post' do
+    response = build_curl_response(status: 200, body: '{"rows":[]}')
+
+    @curl.stubs(:perform)
+      .raises(Curl::Err::PartialFileError)
+      .then.returns(response)
+    @curl.expects(:discard_handle).once
+
+    result = @curl.request(
+      :post,
+      URI('http://localhost:5984/test/_all_docs'),
+      { keys: ['doc/1'] }
+    )
+
+    assert_equal response, result
+  end
+
+  test 'stale connection retry creates a fresh curl handle' do
+    first_handle = @curl.thread_local_handle
+    attempts = 0
+
+    @curl.stubs(:perform).with do |*_args|
+      attempts += 1
+      raise Curl::Err::GotNothingError if attempts == 1
+
+      true
+    end.returns(build_curl_response(status: 200, body: '{"ok":true}'))
+
+    @curl.request(:get, URI('http://localhost:5984/test/doc'), {})
+    second_handle = @curl.thread_local_handle
+
+    assert_equal 2, attempts
+    refute_same first_handle, second_handle
+  end
+
+  test 'discard_handle is safe when no handle exists' do
+    assert_nil @curl.discard_handle
+  end
+
+  test 'discard_handle ignores errors while closing handle' do
+    curl_easy = @curl.thread_local_handle
+    curl_easy.stubs(:close).raises(StandardError, 'broken handle')
+
+    assert_nil @curl.discard_handle
+    assert_nil Thread.current[Dolly::Curl::Connection::THREAD_STORE_KEY][Dolly::Curl::Connection]
+  end
+
+  test 'shared curl connection instances reuse one handle per thread' do
+    other = Dolly::Curl::Connection.new(db_name: 'test', reader: stub_everything('reader'))
+
+    assert_same @curl.thread_local_handle, other.thread_local_handle
+  end
+
+  test 'perform raises for unsupported http methods' do
+    error = assert_raises(ArgumentError) do
+      @curl.send(:perform, :patch, URI('http://localhost:5984/test/doc'), {})
+    end
+
+    assert_match(/unsupported HTTP method/, error.message)
+  end
+
+  test 'apply_get_query! is a no-op for nil or empty data' do
+    curl = Curl::Easy.new
+    curl.url = 'http://localhost:5984/test/doc'
+
+    @curl.send(:apply_get_query!, curl, nil)
+    assert_equal 'http://localhost:5984/test/doc', curl.url
+
+    @curl.send(:apply_get_query!, curl, {})
+    assert_equal 'http://localhost:5984/test/doc', curl.url
+  end
+
+  test 'apply_get_query! appends encoded query parameters' do
+    curl = Curl::Easy.new
+    curl.url = 'http://localhost:5984/test/doc'
+
+    @curl.send(:apply_get_query!, curl, { 'a' => '1', :b => 'two' })
+
+    assert_equal 'http://localhost:5984/test/doc?a=1&b=two', curl.url
+  end
+
+  test 'apply_get_query! uses ampersand when url already has query string' do
+    curl = Curl::Easy.new
+    curl.url = 'http://localhost:5984/test/doc?rev=1'
+
+    @curl.send(:apply_get_query!, curl, { include_docs: true })
+
+    assert_equal 'http://localhost:5984/test/doc?rev=1&include_docs=true', curl.url
+  end
+
+  test 'payload_json returns strings unchanged' do
+    payload = '{"ok":true}'
+
+    assert_equal payload, @curl.send(:payload_json, payload)
+  end
+
+  test 'payload_json encodes hashes as json' do
+    assert_equal '{"ok":true}', @curl.send(:payload_json, ok: true)
+  end
+
+  test 'put raises AmbiguousWriteError and does not blind retry' do
+    put_uri = URI('http://localhost:5984/test/doc%2F1')
+    put_calls = 0
+
+    @curl.stubs(:perform).with do |method, *_|
+      put_calls += 1 if method.to_sym == :put
+      true
+    end.raises(Curl::Err::RecvError)
+    @reader.stubs(:fetch_document).returns(nil)
+    @curl.expects(:discard_handle).at_least_once
+
+    error = assert_raises(Dolly::AmbiguousWriteError) do
+      @curl.request(:put, put_uri, { _id: 'doc/1', _rev: '1-abc', foo: 'bar' })
+    end
+
+    assert_equal 1, put_calls
+    assert_equal :put, error.method
+    assert_equal put_uri, error.uri
+    assert_kind_of Curl::Err::RecvError, error.cause
+  end
+
+  test 'put reconciles when committed document matches payload' do
+    put_uri = URI('http://localhost:5984/test/doc%2F1')
+    payload = { _id: 'doc/1', foo: 'bar' }
+    stored = { _id: 'doc/1', _rev: '2-new', foo: 'bar' }
+
+    @curl.stubs(:perform).raises(Curl::Err::RecvError)
+    @reader.stubs(:fetch_document).returns(stored)
+
+    result = @curl.request(:put, put_uri, payload)
+
+    assert_equal({ ok: true, id: 'doc/1', rev: '2-new' }, result)
+  end
+
+  test 'put retries once when create never landed' do
+    put_uri = URI('http://localhost:5984/test/doc%2F1')
+    payload = { _id: 'doc/1', foo: 'bar' }
+    response = build_curl_response(status: 201, body: '{"ok":true,"id":"doc/1","rev":"1-abc"}')
+    put_calls = 0
+
+    @curl.stubs(:perform).with do |method, *_|
+      put_calls += 1 if method.to_sym == :put
+      true
+    end.raises(Curl::Err::GotNothingError).then.returns(response)
+    @reader.stubs(:fetch_document).returns(nil)
+
+    result = @curl.request(:put, put_uri, payload)
+
+    assert_equal response, result
+    assert_equal 2, put_calls
+  end
+
+  test 'put retries once when source revision is unchanged' do
+    put_uri = URI('http://localhost:5984/test/doc%2F1')
+    payload = { _id: 'doc/1', _rev: '1-abc', foo: 'baz' }
+    stored = { _id: 'doc/1', _rev: '1-abc', foo: 'bar' }
+    response = build_curl_response(status: 201, body: '{"ok":true,"id":"doc/1","rev":"2-def"}')
+    put_calls = 0
+
+    @curl.stubs(:perform).with do |method, *_|
+      put_calls += 1 if method.to_sym == :put
+      true
+    end.raises(Curl::Err::PartialFileError).then.returns(response)
+    @reader.stubs(:fetch_document).returns(stored)
+
+    result = @curl.request(:put, put_uri, payload)
+
+    assert_equal response, result
+    assert_equal 2, put_calls
+  end
+
+  test 'put raises AmbiguousWriteError when stored content conflicts' do
+    put_uri = URI('http://localhost:5984/test/doc%2F1')
+    payload = { _id: 'doc/1', _rev: '1-abc', foo: 'bar' }
+    stored = { _id: 'doc/1', _rev: '2-other', foo: 'other' }
+
+    @curl.stubs(:perform).raises(Curl::Err::RecvError)
+    @reader.stubs(:fetch_document).returns(stored)
+
+    assert_raises(Dolly::AmbiguousWriteError) do
+      @curl.request(:put, put_uri, payload)
+    end
+  end
+
+  test 'attachment put raises AmbiguousWriteError without blind retry' do
+    put_uri = URI('http://localhost:5984/test/doc%2F1/attachment.txt')
+    put_calls = 0
+
+    @curl.stubs(:perform).with do |method, *_|
+      put_calls += 1 if method.to_sym == :put
+      true
+    end.raises(Curl::Err::RecvError)
+
+    assert_raises(Dolly::AmbiguousWriteError) do
+      @curl.request(:put, put_uri, { _body: 'payload' })
+    end
+
+    assert_equal 1, put_calls
+  end
+
+  test 'delete reconciles when document is gone' do
+    delete_uri = URI('http://localhost:5984/test/doc%2F1?rev=1-abc')
+
+    @curl.stubs(:perform).raises(Curl::Err::RecvError)
+    @reader.stubs(:fetch_document).returns(nil)
+
+    result = @curl.request(:delete, delete_uri, nil)
+
+    assert_equal({ ok: true, id: 'doc/1' }, result)
+  end
+
+  test 'delete retries once when same revision is still present' do
+    delete_uri = URI('http://localhost:5984/test/doc%2F1?rev=1-abc')
+    stored = { _id: 'doc/1', _rev: '1-abc', foo: 'bar' }
+    response = build_curl_response(status: 200, body: '{"ok":true}')
+    delete_calls = 0
+
+    @curl.stubs(:perform).with do |method, *_|
+      delete_calls += 1 if method.to_sym == :delete
+      true
+    end.raises(Curl::Err::GotNothingError).then.returns(response)
+    @reader.stubs(:fetch_document).returns(stored)
+
+    result = @curl.request(:delete, delete_uri, nil)
+
+    assert_equal response, result
+    assert_equal 2, delete_calls
+  end
+
+  test 'delete raises AmbiguousWriteError when revision changed' do
+    delete_uri = URI('http://localhost:5984/test/doc%2F1?rev=1-abc')
+    stored = { _id: 'doc/1', _rev: '2-new', foo: 'bar' }
+
+    @curl.stubs(:perform).raises(Curl::Err::RecvError)
+    @reader.stubs(:fetch_document).returns(stored)
+
+    assert_raises(Dolly::AmbiguousWriteError) do
+      @curl.request(:delete, delete_uri, nil)
+    end
+  end
+
+  test 'unknown write post raises AmbiguousWriteError without blind retry' do
+    post_uri = URI('http://localhost:5984/test/_index')
+    post_calls = 0
+
+    @curl.stubs(:perform).with do |method, *_|
+      post_calls += 1 if method.to_sym == :post
+      true
+    end.raises(Curl::Err::RecvError)
+
+    error = assert_raises(Dolly::AmbiguousWriteError) do
+      @curl.request(:post, post_uri, { name: 'demo', index: { fields: ['_id'] } })
+    end
+
+    assert_equal 1, post_calls
+    assert_equal :post, error.method
+    assert_kind_of Curl::Err::RecvError, error.cause
+  end
+
+  test 'bulk docs reconciles when all documents are already committed' do
+    bulk_uri = URI('http://localhost:5984/test/_bulk_docs')
+    docs = [
+      { _id: 'doc/1', name: 'a' },
+      { _id: 'doc/2', name: 'b' }
+    ]
+    post_calls = 0
+
+    @curl.stubs(:perform).with do |method, uri, *_|
+      post_calls += 1 if method.to_sym == :post && uri.path.end_with?('/_bulk_docs')
+      true
+    end.raises(Curl::Err::RecvError)
+    @reader.stubs(:fetch_documents_by_ids).returns(
+      'doc/1' => { id: 'doc/1', doc: { _id: 'doc/1', _rev: '1-a', name: 'a' } },
+      'doc/2' => { id: 'doc/2', doc: { _id: 'doc/2', _rev: '1-b', name: 'b' } }
+    )
+
+    result = @curl.request(:post, bulk_uri, { docs: docs })
+
+    assert_equal(
+      [
+        { ok: true, id: 'doc/1', rev: '1-a' },
+        { ok: true, id: 'doc/2', rev: '1-b' }
+      ],
+      result
+    )
+    assert_equal 1, post_calls
+  end
+
+  test 'bulk docs retries only unapplied documents' do
+    bulk_uri = URI('http://localhost:5984/test/_bulk_docs')
+    docs = [
+      { _id: 'doc/1', name: 'a' },
+      { _id: 'doc/2', name: 'b' }
+    ]
+    pending_payloads = []
+    retry_response = build_curl_response(
+      status: 200,
+      body: '[{"ok":true,"id":"doc/2","rev":"1-b"}]'
+    )
+
+    @curl.stubs(:perform).with do |method, uri, data, *_|
+      if method.to_sym == :post && uri.path.end_with?('/_bulk_docs')
+        pending_payloads << data
+        raise Curl::Err::RecvError if pending_payloads.size == 1
+      end
+      true
+    end.returns(retry_response)
+    @reader.stubs(:fetch_documents_by_ids).returns(
+      'doc/1' => { id: 'doc/1', doc: { _id: 'doc/1', _rev: '1-a', name: 'a' } },
+      'doc/2' => { id: 'doc/2', error: 'not_found' }
+    )
+
+    result = @curl.request(:post, bulk_uri, { docs: docs })
+
+    assert_equal [{ docs: [{ _id: 'doc/2', name: 'b' }] }], pending_payloads.drop(1)
+    assert_equal(
+      [
+        { ok: true, id: 'doc/1', rev: '1-a' },
+        { ok: true, id: 'doc/2', rev: '1-b' }
+      ],
+      result
+    )
+  end
+
+  test 'bulk docs raises AmbiguousWriteError on conflicting content' do
+    bulk_uri = URI('http://localhost:5984/test/_bulk_docs')
+    docs = [{ _id: 'doc/1', name: 'a' }]
+
+    @curl.stubs(:perform).raises(Curl::Err::RecvError)
+    @reader.stubs(:fetch_documents_by_ids).returns(
+      'doc/1' => { id: 'doc/1', doc: { _id: 'doc/1', _rev: '1-a', name: 'other' } }
+    )
+
+    assert_raises(Dolly::AmbiguousWriteError) do
+      @curl.request(:post, bulk_uri, { docs: docs })
+    end
+  end
+
+  private
+
+  def build_curl_response(status:, body:, headers: '')
+    stub(status: status.to_s, body_str: body, header_str: headers)
+  end
+
+  def clear_thread_local_curl!
+    store = Thread.current[Dolly::Curl::Connection::THREAD_STORE_KEY]
+    return unless store
+
+    store.each_value { |handle| handle.close rescue nil }
+    store.clear
+    Thread.current[Dolly::Curl::Connection::THREAD_STORE_KEY] = nil
+  end
+end

--- a/test/mango_index_test.rb
+++ b/test/mango_index_test.rb
@@ -32,7 +32,7 @@ class MangoIndexTest < Test::Unit::TestCase
     ]}.to_json)
   end
 
-  test '#create_in_database' do
+  test '#create_in_database skips when migrations are disabled' do
     assert_equal "Migrations for design_skipped skiped.", Dolly::MangoIndex.create_in_database(
       :design_skipped,
       "demo",
@@ -40,7 +40,7 @@ class MangoIndexTest < Test::Unit::TestCase
     )
   end
 
-  test '#create_in_database' do
+  test '#create_in_database posts index to database' do
     stub_request(:post, "http://localhost:5984/test/_index").
       to_return(status: 200, body: "Design doc run", headers: {})
 


### PR DESCRIPTION
Curb 1.3.x keeps HTTP connections alive, leaking one TCP socket per request and exhausting CouchDB's accept backlog during bursts (Sidekiq jobs, seeds).

Reuse one Curl::Easy handle per thread instead of opening a socket per request.
On stale keep-alive errors (GotNothingError, RecvError, SendError, PartialFileError), discard the dead handle and retry safe reads (GET, HEAD, /_find, /_all_docs) once.

All transport helpers live under the new Dolly::Curl namespace; the public Dolly::Connection API is unchanged. Apps can drop the monkey-patch after upgrading.